### PR TITLE
feat: Polish receipt generator (paragon fiskalny)

### DIFF
--- a/backend/Services/PrinterService.cs
+++ b/backend/Services/PrinterService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using ESCPOS_NET;
 using ESCPOS_NET.Emitters;
 using ESCPOS_NET.Utilities;
@@ -15,6 +16,12 @@ public class PrinterService : IPrinterService
 {
     private readonly ILogger<PrinterService> _logger;
     private const string PrinterAddress = "192.168.123.100:9100";
+
+    static PrinterService()
+    {
+        // Register code page encoding provider for Windows-1250, CP852, etc.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
 
     public PrinterService(ILogger<PrinterService> logger)
     {
@@ -35,11 +42,16 @@ public class PrinterService : IPrinterService
             var byteContent = new List<byte[]>();
             var hasCutContent = false;
 
+            // Determine text encoding based on code page
+            Encoding textEncoding = Encoding.UTF8; // default
             if (options?.CodePage != null)
             {
                 var codePage = MapCodePage(options.CodePage);
                 if (codePage.HasValue)
+                {
                     byteContent.Add(e.CodePage(codePage.Value));
+                    textEncoding = GetEncodingForCodePage(options.CodePage);
+                }
             }
 
             if (options?.DefaultLineSpacing != null)
@@ -57,7 +69,7 @@ public class PrinterService : IPrinterService
                 switch (item.Type)
                 {
                     case ContentType.Text:
-                        byteContent.AddRange(BuildTextBytes(e, item));
+                        byteContent.AddRange(BuildTextBytes(e, item, textEncoding));
                         break;
 
                     case ContentType.Image:
@@ -97,7 +109,7 @@ public class PrinterService : IPrinterService
 
                     case ContentType.Separator:
                         var sep = new string((item.SeparatorChar ?? "=")[0], item.SeparatorLength ?? 32);
-                        byteContent.AddRange(BuildStyledTextBytes(e, sep, item.Style));
+                        byteContent.AddRange(BuildStyledTextBytes(e, sep, item.Style, textEncoding));
                         break;
 
                     case ContentType.CodePage:
@@ -132,10 +144,10 @@ public class PrinterService : IPrinterService
         }
     }
 
-    private List<byte[]> BuildTextBytes(EPSON e, PrintContent item)
-        => BuildStyledTextBytes(e, item.Content ?? string.Empty, item.Style);
+    private List<byte[]> BuildTextBytes(EPSON e, PrintContent item, Encoding encoding)
+        => BuildStyledTextBytes(e, item.Content ?? string.Empty, item.Style, encoding);
 
-    private List<byte[]> BuildStyledTextBytes(EPSON e, string text, List<Models.PrintStyle>? styles)
+    private List<byte[]> BuildStyledTextBytes(EPSON e, string text, List<Models.PrintStyle>? styles, Encoding encoding)
     {
         var bytes = new List<byte[]>();
         var hasReverse = styles?.Contains(Models.PrintStyle.ReverseMode) == true;
@@ -147,7 +159,12 @@ public class PrinterService : IPrinterService
             bytes.Add(e.UpsideDownMode(true));
 
         bytes.Add(e.SetStyles(MapPrintStyles(styles)));
-        bytes.Add(e.PrintLine(text));
+
+        // Encode text using the specified code page encoding
+        var textBytes = encoding.GetBytes(text);
+        var newLine = new byte[] { 0x0A }; // LF
+        bytes.Add([.. textBytes, .. newLine]);
+
         bytes.Add(e.SetStyles(EscPrintStyle.None));
 
         if (hasUpsideDown)
@@ -316,13 +333,29 @@ public class PrinterService : IPrinterService
         _ => CorrectionLevel2DCode.PERCENT_7
     };
 
-    private CodePage? MapCodePage(string name) => name.ToUpper() switch
+    private static CodePage? MapCodePage(string name) => name.ToUpper() switch
     {
         "PC437" or "PC437_USA" => CodePage.PC437_USA_STANDARD_EUROPE_DEFAULT,
         "PC858" or "PC858_EURO" => CodePage.PC858_EURO,
         "KATAKANA" => CodePage.KATAKANA,
         "PC850" => CodePage.PC850_MULTILINGUAL,
         "WPC1252" => CodePage.WPC1252,
+        // Polish / Central European
+        "PC852" or "LATIN2" => CodePage.PC852_LATIN2,
+        "WPC1250" => CodePage.WPC1250_LATIN2,
+        "ISO8859_2" or "ISO88592" => CodePage.ISO8859_2_LATIN2,
         _ => null
+    };
+
+    private static Encoding GetEncodingForCodePage(string name) => name.ToUpper() switch
+    {
+        "PC852" or "LATIN2" => Encoding.GetEncoding(852),
+        "WPC1250" => Encoding.GetEncoding(1250),
+        "ISO8859_2" or "ISO88592" => Encoding.GetEncoding(28592), // ISO-8859-2
+        "WPC1252" => Encoding.GetEncoding(1252),
+        "PC850" => Encoding.GetEncoding(850),
+        "PC858" or "PC858_EURO" => Encoding.GetEncoding(858),
+        "PC437" or "PC437_USA" => Encoding.GetEncoding(437),
+        _ => Encoding.UTF8
     };
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Link, useLocation } from "react-router-dom";
 import Home from "./pages/Home";
 import Builder from "./pages/Builder";
+import Receipts from "./pages/Receipts";
 import "./index.css";
 import { Button } from "@/components/ui/button";
 import { Printer } from "lucide-react";
@@ -39,6 +40,13 @@ function Navigation() {
             >
               <Link to="/builder">Template Builder</Link>
             </Button>
+            <Button
+              asChild
+              variant={location.pathname === "/receipts" ? "default" : "ghost"}
+              className="font-mono"
+            >
+              <Link to="/receipts">Receipts</Link>
+            </Button>
             <ThemeToggle />
           </div>
         </div>
@@ -60,6 +68,7 @@ function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/builder" element={<Builder />} />
+              <Route path="/receipts" element={<Receipts />} />
             </Routes>
           </main>
 

--- a/frontend/src/components/receipt-preview.tsx
+++ b/frontend/src/components/receipt-preview.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Receipt } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import type { ReceiptData, TaxRates } from "@/types/receipt";
+import {
+  calculateItemTotal,
+  calculateSubtotal,
+  calculateTaxBreakdown,
+  calculateTotalTax,
+  formatCurrency,
+  formatQuantity,
+  formatDate,
+} from "@/lib/receipt-utils";
+
+interface ReceiptPreviewProps {
+  receipt: ReceiptData;
+  taxRates: TaxRates;
+}
+
+export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const { store, items, payment, title, date } = receipt;
+  const subtotal = calculateSubtotal(items);
+  const breakdown = calculateTaxBreakdown(items, taxRates);
+  const totalTax = calculateTotalTax(breakdown);
+
+  const hasContent = store.name || items.length > 0;
+
+  if (!hasContent) return null;
+
+  return (
+    <Card className="overflow-hidden border-2">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between p-4 hover:bg-muted/50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <Receipt className="h-4 w-4 text-[hsl(var(--terminal-green))]" />
+          <span className="font-semibold text-sm">Receipt Preview</span>
+        </div>
+        {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </button>
+
+      {isExpanded && (
+        <div className="p-4 border-t-2">
+          <div className="receipt-paper perforated-top rounded-lg shadow-lg p-4 max-w-[320px] mx-auto font-mono text-sm bg-white text-black">
+            {/* Header */}
+            <div className="text-center space-y-0.5">
+              {store.name && (
+                <div className="font-bold text-base tracking-wide">{store.name}</div>
+              )}
+              {store.addressLine1 && <div>{store.addressLine1}</div>}
+              {store.addressLine2 && <div>{store.addressLine2}</div>}
+              {store.nip && <div>NIP: {store.nip}</div>}
+            </div>
+
+            {/* Title */}
+            <div className="my-3 text-center">
+              <div className="font-bold text-lg tracking-widest">
+                {title || 'PARAGON FISKALNY'}
+              </div>
+            </div>
+
+            <div className="border-t border-dashed border-gray-400 my-2" />
+
+            {/* Line items */}
+            {items.length > 0 && (
+              <div className="space-y-2">
+                {items.map((item) => {
+                  const total = calculateItemTotal(item);
+                  return (
+                    <div key={item.id}>
+                      <div className="truncate">{item.name || '(no name)'}</div>
+                      <div className="text-right text-xs">
+                        {formatQuantity(item.quantity)} x {formatCurrency(item.unitPrice)} = {formatCurrency(total)} {item.taxCategory}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {items.length === 0 && (
+              <div className="text-center text-gray-400 py-2">No items</div>
+            )}
+
+            <div className="border-t border-dashed border-gray-400 my-2" />
+
+            {/* Tax breakdown */}
+            {breakdown.length > 0 && (
+              <div className="space-y-0.5 text-xs">
+                {breakdown.map((line) => (
+                  <div key={line.category}>
+                    <div className="flex justify-between">
+                      <span>Sp.op.{line.category}</span>
+                      <span>{formatCurrency(line.base)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>PTU {line.category}={line.rate},00%</span>
+                      <span>{formatCurrency(line.tax)}</span>
+                    </div>
+                  </div>
+                ))}
+                <div className="flex justify-between font-semibold">
+                  <span>SUMA PTU</span>
+                  <span>{formatCurrency(totalTax)}</span>
+                </div>
+              </div>
+            )}
+
+            <div className="border-t border-dashed border-gray-400 my-2" />
+
+            {/* Total */}
+            <div className="flex justify-between font-bold text-lg">
+              <span>SUMA PLN</span>
+              <span>{formatCurrency(subtotal)}</span>
+            </div>
+
+            <div className="border-t border-dashed border-gray-400 my-2" />
+
+            {/* Payment */}
+            <div className="text-center text-xs mb-1">ROZLICZENIE PLATNOSCI</div>
+            <div className="space-y-0.5 text-xs">
+              {(payment.method === 'cash' || payment.method === 'mixed') && (
+                <div className="flex justify-between">
+                  <span>ZAPLACONO GOTOWKA PLN</span>
+                  <span>{formatCurrency(payment.cashAmount ?? (payment.method === 'cash' ? subtotal : 0))}</span>
+                </div>
+              )}
+              {(payment.method === 'card' || payment.method === 'mixed') && (
+                <div className="flex justify-between">
+                  <span>ZAPLACONO KARTA PLN</span>
+                  <span>{formatCurrency(payment.cardAmount ?? (payment.method === 'card' ? subtotal : 0))}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Date */}
+            <div className="text-center text-xs mt-3">
+              {date || formatDate()}
+            </div>
+
+            {/* Cut line */}
+            <div className="text-center text-xs opacity-40 mt-4">
+              ✂ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ✂
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/receipt-preview.tsx
+++ b/frontend/src/components/receipt-preview.tsx
@@ -11,6 +11,7 @@ import {
   formatQuantity,
   formatDate,
 } from "@/lib/receipt-utils";
+import { CHARS_PER_LINE } from "@/lib/printer-constants";
 
 interface ReceiptPreviewProps {
   receipt: ReceiptData;
@@ -25,9 +26,7 @@ export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
   const breakdown = calculateTaxBreakdown(items, taxRates);
   const totalTax = calculateTotalTax(breakdown);
 
-  const hasContent = store.name || items.length > 0;
-
-  if (!hasContent) return null;
+  // Always show preview
 
   return (
     <Card className="overflow-hidden border-2">
@@ -51,7 +50,7 @@ export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
                 <div className="font-bold text-base tracking-wide">{store.name}</div>
               )}
               {store.addressLine1 && <div>{store.addressLine1}</div>}
-              {store.addressLine2 && <div>{store.addressLine2}</div>}
+              {(store.city || store.zipCode) && <div>{store.zipCode} {store.city}</div>}
               {store.nip && <div>NIP: {store.nip}</div>}
             </div>
 
@@ -66,15 +65,22 @@ export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
 
             {/* Line items */}
             {items.length > 0 && (
-              <div className="space-y-2">
+              <div className="space-y-1">
                 {items.map((item) => {
                   const total = calculateItemTotal(item);
-                  return (
+                  const name = item.name || '(no name)';
+                  const priceStr = `${formatQuantity(item.quantity)} SZT * ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`;
+                  const fitsOneLine = name.length + priceStr.length + 1 <= CHARS_PER_LINE.normal;
+
+                  return fitsOneLine ? (
+                    <div key={item.id} className="flex justify-between text-xs">
+                      <span className="truncate">{name}</span>
+                      <span className="ml-2 whitespace-nowrap">{priceStr}</span>
+                    </div>
+                  ) : (
                     <div key={item.id}>
-                      <div className="truncate">{item.name || '(no name)'}</div>
-                      <div className="text-right text-xs">
-                        {formatQuantity(item.quantity)} x {formatCurrency(item.unitPrice)} = {formatCurrency(total)} {item.taxCategory}
-                      </div>
+                      <div className="truncate text-xs">{name}</div>
+                      <div className="text-right text-xs">{priceStr}</div>
                     </div>
                   );
                 })}

--- a/frontend/src/lib/receipt-utils.ts
+++ b/frontend/src/lib/receipt-utils.ts
@@ -1,0 +1,301 @@
+import type { PrintContent } from '../types/printer';
+import { ContentType, Alignment, PrintStyle } from '../types/printer';
+import type {
+  ReceiptData,
+  ReceiptItem,
+  TaxRates,
+  TaxBreakdownLine,
+  StoreInfo,
+  TaxCategory,
+} from '../types/receipt';
+import { DEFAULT_TAX_RATES, DEFAULT_STORE } from '../types/receipt';
+
+// Storage keys
+const STORAGE_KEYS = {
+  STORE: 'receipt-store-defaults',
+  TAX_RATES: 'receipt-tax-rates',
+} as const;
+
+// Calculations
+export function calculateItemTotal(item: ReceiptItem): number {
+  return item.quantity * item.unitPrice;
+}
+
+export function calculateSubtotal(items: ReceiptItem[]): number {
+  return items.reduce((sum, item) => sum + calculateItemTotal(item), 0);
+}
+
+export function calculateTaxBreakdown(items: ReceiptItem[], rates: TaxRates): TaxBreakdownLine[] {
+  const byCategory = items.reduce((acc, item) => {
+    const cat = item.taxCategory;
+    if (!acc[cat]) {
+      acc[cat] = { base: 0, rate: rates[cat] };
+    }
+    acc[cat].base += calculateItemTotal(item);
+    return acc;
+  }, {} as Record<TaxCategory, { base: number; rate: number }>);
+
+  return (Object.entries(byCategory) as [TaxCategory, { base: number; rate: number }][])
+    .map(([category, { base, rate }]) => {
+      // Polish tax: price is gross, tax = gross - (gross / (1 + rate/100))
+      const netBase = base / (1 + rate / 100);
+      const tax = base - netBase;
+      return {
+        category,
+        rate,
+        base: netBase,
+        tax,
+      };
+    })
+    .filter(line => line.base > 0)
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+export function calculateTotalTax(breakdown: TaxBreakdownLine[]): number {
+  return breakdown.reduce((sum, line) => sum + line.tax, 0);
+}
+
+// Formatting
+export function formatCurrency(amount: number): string {
+  return amount.toFixed(2).replace('.', ',');
+}
+
+export function formatQuantity(qty: number): string {
+  return qty % 1 === 0 ? qty.toString() : qty.toFixed(3).replace('.', ',');
+}
+
+export function formatDate(date?: Date): string {
+  const d = date || new Date();
+  const day = d.getDate().toString().padStart(2, '0');
+  const month = (d.getMonth() + 1).toString().padStart(2, '0');
+  const year = d.getFullYear();
+  const hours = d.getHours().toString().padStart(2, '0');
+  const minutes = d.getMinutes().toString().padStart(2, '0');
+  return `${day}.${month}.${year} ${hours}:${minutes}`;
+}
+
+// LocalStorage persistence
+export function getDefaultStore(): StoreInfo {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.STORE);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // ignore
+  }
+  return { ...DEFAULT_STORE };
+}
+
+export function saveDefaultStore(store: StoreInfo): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.STORE, JSON.stringify(store));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function getTaxRates(): TaxRates {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.TAX_RATES);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // ignore
+  }
+  return { ...DEFAULT_TAX_RATES };
+}
+
+export function saveTaxRates(rates: TaxRates): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.TAX_RATES, JSON.stringify(rates));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+// Convert receipt to PrintContent[] for API
+export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): PrintContent[] {
+  const content: PrintContent[] = [];
+  const { store, items, payment, title, date } = receipt;
+
+  // Header - Store info (centered)
+  if (store.name) {
+    content.push({
+      type: ContentType.Text,
+      content: store.name,
+      alignment: Alignment.Center,
+      style: [PrintStyle.DoubleWidth],
+    });
+  }
+  if (store.addressLine1) {
+    content.push({
+      type: ContentType.Text,
+      content: store.addressLine1,
+      alignment: Alignment.Center,
+    });
+  }
+  if (store.addressLine2) {
+    content.push({
+      type: ContentType.Text,
+      content: store.addressLine2,
+      alignment: Alignment.Center,
+    });
+  }
+  if (store.nip) {
+    content.push({
+      type: ContentType.Text,
+      content: `NIP: ${store.nip}`,
+      alignment: Alignment.Center,
+    });
+  }
+
+  // Separator
+  content.push({ type: ContentType.LineFeed, lines: 1 });
+
+  // Title
+  content.push({
+    type: ContentType.Text,
+    content: title || 'PARAGON FISKALNY',
+    alignment: Alignment.Center,
+    style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
+  });
+
+  content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
+
+  // Line items
+  for (const item of items) {
+    const total = calculateItemTotal(item);
+    // Item name
+    content.push({
+      type: ContentType.Text,
+      content: item.name,
+      alignment: Alignment.Left,
+    });
+    // Qty x price = total + tax category
+    content.push({
+      type: ContentType.Text,
+      content: `  ${formatQuantity(item.quantity)} x ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`,
+      alignment: Alignment.Right,
+    });
+  }
+
+  content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
+
+  // Tax breakdown
+  const breakdown = calculateTaxBreakdown(items, taxRates);
+  for (const line of breakdown) {
+    content.push({
+      type: ContentType.Text,
+      content: `Sp.op.${line.category}`,
+      alignment: Alignment.Left,
+    });
+    content.push({
+      type: ContentType.Text,
+      content: formatCurrency(line.base),
+      alignment: Alignment.Right,
+    });
+    content.push({
+      type: ContentType.Text,
+      content: `PTU ${line.category}=${line.rate},00%`,
+      alignment: Alignment.Left,
+    });
+    content.push({
+      type: ContentType.Text,
+      content: formatCurrency(line.tax),
+      alignment: Alignment.Right,
+    });
+  }
+
+  const totalTax = calculateTotalTax(breakdown);
+  content.push({
+    type: ContentType.Text,
+    content: 'SUMA PTU',
+    alignment: Alignment.Left,
+  });
+  content.push({
+    type: ContentType.Text,
+    content: formatCurrency(totalTax),
+    alignment: Alignment.Right,
+  });
+
+  content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
+
+  // Total
+  const subtotal = calculateSubtotal(items);
+  content.push({
+    type: ContentType.Text,
+    content: 'SUMA PLN',
+    alignment: Alignment.Left,
+    style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
+  });
+  content.push({
+    type: ContentType.Text,
+    content: formatCurrency(subtotal),
+    alignment: Alignment.Right,
+    style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
+  });
+
+  content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
+
+  // Payment
+  content.push({
+    type: ContentType.Text,
+    content: 'ROZLICZENIE PLATNOSCI',
+    alignment: Alignment.Center,
+  });
+
+  if (payment.method === 'cash' || payment.method === 'mixed') {
+    const cashAmt = payment.cashAmount ?? (payment.method === 'cash' ? subtotal : 0);
+    content.push({
+      type: ContentType.Text,
+      content: `ZAPLACONO GOTOWKA PLN`,
+      alignment: Alignment.Left,
+    });
+    content.push({
+      type: ContentType.Text,
+      content: formatCurrency(cashAmt),
+      alignment: Alignment.Right,
+    });
+  }
+
+  if (payment.method === 'card' || payment.method === 'mixed') {
+    const cardAmt = payment.cardAmount ?? (payment.method === 'card' ? subtotal : 0);
+    content.push({
+      type: ContentType.Text,
+      content: `ZAPLACONO KARTA PLN`,
+      alignment: Alignment.Left,
+    });
+    content.push({
+      type: ContentType.Text,
+      content: formatCurrency(cardAmt),
+      alignment: Alignment.Right,
+    });
+  }
+
+  // Date/time
+  content.push({ type: ContentType.LineFeed, lines: 1 });
+  content.push({
+    type: ContentType.Text,
+    content: date || formatDate(),
+    alignment: Alignment.Center,
+  });
+
+  // Feed and cut
+  content.push({ type: ContentType.LineFeed, lines: 3 });
+  content.push({ type: ContentType.Cut });
+
+  return content;
+}
+
+// Create new empty item
+export function createEmptyItem(): ReceiptItem {
+  return {
+    id: crypto.randomUUID(),
+    name: '',
+    quantity: 1,
+    unitPrice: 0,
+    taxCategory: 'A',
+  };
+}

--- a/frontend/src/lib/receipt-utils.ts
+++ b/frontend/src/lib/receipt-utils.ts
@@ -9,6 +9,7 @@ import type {
   TaxCategory,
 } from '../types/receipt';
 import { DEFAULT_TAX_RATES, DEFAULT_STORE } from '../types/receipt';
+import { CHARS_PER_LINE } from './printer-constants';
 
 // Storage keys
 const STORAGE_KEYS = {
@@ -74,6 +75,12 @@ export function formatDate(date?: Date): string {
   return `${day}.${month}.${year} ${hours}:${minutes}`;
 }
 
+// Format left and right text on same line with padding
+export function formatLine(left: string, right: string, width: number = CHARS_PER_LINE.normal): string {
+  const padding = Math.max(1, width - left.length - right.length);
+  return left + ' '.repeat(padding) + right;
+}
+
 // LocalStorage persistence
 export function getDefaultStore(): StoreInfo {
   try {
@@ -136,10 +143,10 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
       alignment: Alignment.Center,
     });
   }
-  if (store.addressLine2) {
+  if (store.city || store.zipCode) {
     content.push({
       type: ContentType.Text,
-      content: store.addressLine2,
+      content: `${store.zipCode} ${store.city}`.trim(),
       alignment: Alignment.Center,
     });
   }
@@ -167,18 +174,28 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
   // Line items
   for (const item of items) {
     const total = calculateItemTotal(item);
-    // Item name
-    content.push({
-      type: ContentType.Text,
-      content: item.name,
-      alignment: Alignment.Left,
-    });
-    // Qty x price = total + tax category
-    content.push({
-      type: ContentType.Text,
-      content: `  ${formatQuantity(item.quantity)} x ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`,
-      alignment: Alignment.Right,
-    });
+    const priceStr = `${formatQuantity(item.quantity)} SZT * ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`;
+
+    // Try to fit on one line, otherwise split
+    if (item.name.length + priceStr.length + 1 <= CHARS_PER_LINE.normal) {
+      // Fits on one line
+      content.push({
+        type: ContentType.Text,
+        content: formatLine(item.name, priceStr),
+      });
+    } else {
+      // Split into two lines
+      content.push({
+        type: ContentType.Text,
+        content: item.name,
+        alignment: Alignment.Left,
+      });
+      content.push({
+        type: ContentType.Text,
+        content: priceStr,
+        alignment: Alignment.Right,
+      });
+    }
   }
 
   content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
@@ -188,36 +205,18 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
   for (const line of breakdown) {
     content.push({
       type: ContentType.Text,
-      content: `Sp.op.${line.category}`,
-      alignment: Alignment.Left,
+      content: formatLine(`Sp.op.${line.category}`, formatCurrency(line.base)),
     });
     content.push({
       type: ContentType.Text,
-      content: formatCurrency(line.base),
-      alignment: Alignment.Right,
-    });
-    content.push({
-      type: ContentType.Text,
-      content: `PTU ${line.category}=${line.rate},00%`,
-      alignment: Alignment.Left,
-    });
-    content.push({
-      type: ContentType.Text,
-      content: formatCurrency(line.tax),
-      alignment: Alignment.Right,
+      content: formatLine(`PTU ${line.category}=${line.rate},00%`, formatCurrency(line.tax)),
     });
   }
 
   const totalTax = calculateTotalTax(breakdown);
   content.push({
     type: ContentType.Text,
-    content: 'SUMA PTU',
-    alignment: Alignment.Left,
-  });
-  content.push({
-    type: ContentType.Text,
-    content: formatCurrency(totalTax),
-    alignment: Alignment.Right,
+    content: formatLine('SUMA PTU', formatCurrency(totalTax)),
   });
 
   content.push({ type: ContentType.Separator, separatorChar: '-', separatorLength: 32 });
@@ -226,14 +225,7 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
   const subtotal = calculateSubtotal(items);
   content.push({
     type: ContentType.Text,
-    content: 'SUMA PLN',
-    alignment: Alignment.Left,
-    style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
-  });
-  content.push({
-    type: ContentType.Text,
-    content: formatCurrency(subtotal),
-    alignment: Alignment.Right,
+    content: formatLine('SUMA PLN', formatCurrency(subtotal), CHARS_PER_LINE.doubleWidth),
     style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
   });
 
@@ -250,13 +242,7 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
     const cashAmt = payment.cashAmount ?? (payment.method === 'cash' ? subtotal : 0);
     content.push({
       type: ContentType.Text,
-      content: `ZAPLACONO GOTOWKA PLN`,
-      alignment: Alignment.Left,
-    });
-    content.push({
-      type: ContentType.Text,
-      content: formatCurrency(cashAmt),
-      alignment: Alignment.Right,
+      content: formatLine('ZAPLACONO GOTOWKA PLN', formatCurrency(cashAmt)),
     });
   }
 
@@ -264,13 +250,7 @@ export function receiptToContent(receipt: ReceiptData, taxRates: TaxRates): Prin
     const cardAmt = payment.cardAmount ?? (payment.method === 'card' ? subtotal : 0);
     content.push({
       type: ContentType.Text,
-      content: `ZAPLACONO KARTA PLN`,
-      alignment: Alignment.Left,
-    });
-    content.push({
-      type: ContentType.Text,
-      content: formatCurrency(cardAmt),
-      alignment: Alignment.Right,
+      content: formatLine('ZAPLACONO KARTA PLN', formatCurrency(cardAmt)),
     });
   }
 

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -116,6 +116,7 @@ export default function Receipts() {
       await printerApi.printCustom({
         content,
         options: {
+          codePage: 'PC852', // Polish characters (Latin 2)
           autoCut: true,
           feedLinesAfterPrint: 3,
         },

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from "react";
-import { Printer, Plus, Trash2, ChevronDown, ChevronUp, Store, CheckCircle2, AlertCircle } from "lucide-react";
+import { Printer, Plus, Trash2, ChevronDown, ChevronUp, Store, CheckCircle2, AlertCircle, FileText, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { InlineSelect } from "@/components/inline-select";
 import { StatusIndicator } from "@/components/status-indicator";
 import { ReceiptPreview } from "@/components/receipt-preview";
 import { cn } from "@/lib/utils";
@@ -35,6 +34,9 @@ export default function Receipts() {
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
   const [cashAmount, setCashAmount] = useState<string>('');
   const [cardAmount, setCardAmount] = useState<string>('');
+
+  // Template selection
+  const [selectedTemplate, setSelectedTemplate] = useState<string>('paragon-fiskalny');
 
   // UI state
   const [loading, setLoading] = useState(false);
@@ -173,41 +175,50 @@ export default function Receipts() {
               </CardDescription>
             </CardHeader>
             {storeExpanded && (
-              <CardContent className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label className="font-mono text-sm">Store Name</Label>
+              <CardContent className="grid gap-3 sm:grid-cols-4">
+                <div className="sm:col-span-2 space-y-1">
+                  <Label className="font-mono text-xs text-muted-foreground">Store Name</Label>
                   <Input
                     value={store.name}
                     onChange={(e) => updateStore('name', e.target.value)}
                     placeholder="Store name..."
-                    className="font-mono"
+                    className="font-mono h-9"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label className="font-mono text-sm">NIP</Label>
+                <div className="sm:col-span-2 space-y-1">
+                  <Label className="font-mono text-xs text-muted-foreground">NIP</Label>
                   <Input
                     value={store.nip}
                     onChange={(e) => updateStore('nip', e.target.value)}
                     placeholder="1234567890"
-                    className="font-mono"
+                    className="font-mono h-9"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label className="font-mono text-sm">Address Line 1</Label>
+                <div className="sm:col-span-2 space-y-1">
+                  <Label className="font-mono text-xs text-muted-foreground">Street</Label>
                   <Input
                     value={store.addressLine1}
                     onChange={(e) => updateStore('addressLine1', e.target.value)}
-                    placeholder="Street address..."
-                    className="font-mono"
+                    placeholder="ul. Przykładowa 1"
+                    className="font-mono h-9"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label className="font-mono text-sm">Address Line 2</Label>
+                <div className="space-y-1">
+                  <Label className="font-mono text-xs text-muted-foreground">Zip Code</Label>
                   <Input
-                    value={store.addressLine2}
-                    onChange={(e) => updateStore('addressLine2', e.target.value)}
-                    placeholder="City, postal code..."
-                    className="font-mono"
+                    value={store.zipCode}
+                    onChange={(e) => updateStore('zipCode', e.target.value)}
+                    placeholder="00-000"
+                    className="font-mono h-9"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="font-mono text-xs text-muted-foreground">City</Label>
+                  <Input
+                    value={store.city}
+                    onChange={(e) => updateStore('city', e.target.value)}
+                    placeholder="Warszawa"
+                    className="font-mono h-9"
                   />
                 </div>
               </CardContent>
@@ -216,76 +227,68 @@ export default function Receipts() {
 
           {/* Line Items */}
           <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.1s' }}>
-            <CardHeader>
+            <CardHeader className="pb-3">
               <CardTitle className="text-lg font-mono">Line Items</CardTitle>
-              <CardDescription className="font-mono text-xs">
-                Add products or services to the receipt
-              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-2">
               {/* Header row */}
-              <div className="grid grid-cols-12 gap-2 text-xs font-mono text-muted-foreground px-1">
-                <div className="col-span-5">Name</div>
-                <div className="col-span-2 text-center">Qty</div>
-                <div className="col-span-2 text-center">Price</div>
-                <div className="col-span-2 text-center">Tax</div>
-                <div className="col-span-1"></div>
+              <div className="grid grid-cols-[1fr_70px_80px_60px_32px] gap-2 text-xs font-mono text-muted-foreground">
+                <div>Name</div>
+                <div className="text-center">Qty</div>
+                <div className="text-center">Price</div>
+                <div className="text-center">Tax</div>
+                <div></div>
               </div>
 
               {items.map((item) => (
-                <div key={item.id} className="grid grid-cols-12 gap-2 items-center">
-                  <div className="col-span-5">
-                    <Input
-                      value={item.name}
-                      onChange={(e) => updateItem(item.id, { name: e.target.value })}
-                      placeholder="Item name..."
-                      className="font-mono text-sm"
-                    />
-                  </div>
-                  <div className="col-span-2">
-                    <Input
-                      type="number"
-                      value={item.quantity}
-                      onChange={(e) => updateItem(item.id, { quantity: parseFloat(e.target.value) || 0 })}
-                      min="0"
-                      step="1"
-                      className="font-mono text-sm text-center"
-                    />
-                  </div>
-                  <div className="col-span-2">
-                    <Input
-                      type="number"
-                      value={item.unitPrice || ''}
-                      onChange={(e) => updateItem(item.id, { unitPrice: parseFloat(e.target.value) || 0 })}
-                      min="0"
-                      step="0.01"
-                      placeholder="0,00"
-                      className="font-mono text-sm text-center"
-                    />
-                  </div>
-                  <div className="col-span-2">
-                    <InlineSelect
-                      value={item.taxCategory}
-                      onChange={(value) => updateItem(item.id, { taxCategory: value as TaxCategory })}
-                      options={[
-                        { value: 'A', label: 'A 23%' },
-                        { value: 'B', label: 'B 8%' },
-                        { value: 'C', label: 'C 5%' },
-                        { value: 'D', label: 'D 0%' },
-                      ]}
-                    />
-                  </div>
-                  <div className="col-span-1 flex justify-center">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => removeItem(item.id)}
-                      disabled={items.length === 1}
-                      className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
+                <div key={item.id} className="grid grid-cols-[1fr_70px_80px_60px_32px] gap-2 items-center">
+                  <Input
+                    value={item.name}
+                    onChange={(e) => updateItem(item.id, { name: e.target.value })}
+                    placeholder="Item name..."
+                    className="font-mono text-sm h-9"
+                  />
+                  <Input
+                    inputMode="decimal"
+                    value={item.quantity || ''}
+                    onChange={(e) => {
+                      const val = e.target.value.replace(',', '.');
+                      updateItem(item.id, { quantity: parseFloat(val) || 0 });
+                    }}
+                    onFocus={(e) => e.target.select()}
+                    placeholder="1"
+                    className="font-mono text-sm h-9 text-center"
+                  />
+                  <Input
+                    inputMode="decimal"
+                    value={item.unitPrice || ''}
+                    onChange={(e) => {
+                      const val = e.target.value.replace(',', '.');
+                      updateItem(item.id, { unitPrice: parseFloat(val) || 0 });
+                    }}
+                    onFocus={(e) => e.target.select()}
+                    placeholder="0.00"
+                    className="font-mono text-sm h-9 text-center"
+                  />
+                  <select
+                    value={item.taxCategory}
+                    onChange={(e) => updateItem(item.id, { taxCategory: e.target.value as TaxCategory })}
+                    className="h-9 px-2 rounded-md border bg-background font-mono text-sm"
+                  >
+                    <option value="A">A</option>
+                    <option value="B">B</option>
+                    <option value="C">C</option>
+                    <option value="D">D</option>
+                  </select>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeItem(item.id)}
+                    disabled={items.length === 1}
+                    className="h-9 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
                 </div>
               ))}
 
@@ -293,7 +296,7 @@ export default function Receipts() {
                 variant="outline"
                 size="sm"
                 onClick={addItem}
-                className="w-full font-mono"
+                className="w-full font-mono h-9"
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add Item
@@ -301,60 +304,58 @@ export default function Receipts() {
             </CardContent>
           </Card>
 
-          {/* Totals */}
+          {/* Total & Payment */}
           <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.15s' }}>
-            <CardHeader>
-              <CardTitle className="text-lg font-mono">Total</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex justify-between items-center text-2xl font-bold font-mono">
+            <CardContent className="pt-4 space-y-4">
+              <div className="flex justify-between items-center text-xl font-bold font-mono">
                 <span>SUMA PLN</span>
                 <span className="text-[hsl(var(--terminal-green))]">
                   {subtotal.toFixed(2).replace('.', ',')}
                 </span>
               </div>
-            </CardContent>
-          </Card>
 
-          {/* Payment */}
-          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.2s' }}>
-            <CardHeader>
-              <CardTitle className="text-lg font-mono">Payment</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label className="font-mono text-sm">Payment Method</Label>
-                <InlineSelect
-                  value={paymentMethod}
-                  onChange={(value) => setPaymentMethod(value as PaymentMethod)}
-                  options={[
-                    { value: 'cash', label: 'Cash' },
-                    { value: 'card', label: 'Card' },
-                    { value: 'mixed', label: 'Mixed' },
-                  ]}
-                />
+              <div className="flex items-center gap-3">
+                <Label className="font-mono text-xs text-muted-foreground whitespace-nowrap">Payment</Label>
+                <div className="flex gap-1">
+                  {(['cash', 'card', 'mixed'] as const).map((method) => (
+                    <button
+                      key={method}
+                      onClick={() => setPaymentMethod(method)}
+                      className={cn(
+                        "px-3 py-1.5 text-xs font-mono rounded border transition-colors",
+                        paymentMethod === method
+                          ? "border-[hsl(var(--terminal-green))] bg-[hsl(var(--terminal-green))]/10 text-[hsl(var(--terminal-green))]"
+                          : "border-muted hover:border-muted-foreground/50"
+                      )}
+                    >
+                      {method === 'cash' ? 'Gotówka' : method === 'card' ? 'Karta' : 'Mix'}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               {paymentMethod === 'mixed' && (
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label className="font-mono text-sm">Cash Amount</Label>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label className="font-mono text-xs text-muted-foreground">Gotówka</Label>
                     <Input
-                      type="number"
+                      inputMode="decimal"
                       value={cashAmount}
-                      onChange={(e) => setCashAmount(e.target.value)}
+                      onChange={(e) => setCashAmount(e.target.value.replace(',', '.'))}
+                      onFocus={(e) => e.target.select()}
                       placeholder={subtotal.toFixed(2)}
-                      className="font-mono"
+                      className="font-mono h-9"
                     />
                   </div>
-                  <div className="space-y-2">
-                    <Label className="font-mono text-sm">Card Amount</Label>
+                  <div className="space-y-1">
+                    <Label className="font-mono text-xs text-muted-foreground">Karta</Label>
                     <Input
-                      type="number"
+                      inputMode="decimal"
                       value={cardAmount}
-                      onChange={(e) => setCardAmount(e.target.value)}
+                      onChange={(e) => setCardAmount(e.target.value.replace(',', '.'))}
+                      onFocus={(e) => e.target.select()}
                       placeholder="0.00"
-                      className="font-mono"
+                      className="font-mono h-9"
                     />
                   </div>
                 </div>
@@ -411,9 +412,42 @@ export default function Receipts() {
           </div>
         </div>
 
-        {/* Right Sidebar - Preview */}
+        {/* Right Sidebar - Template & Preview */}
         <div className="lg:col-span-1 space-y-6">
-          <div className="matrix-cascade" style={{ animationDelay: '0.25s' }}>
+          {/* Template Selection */}
+          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.25s' }}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <FileText className="h-5 w-5 text-[hsl(var(--terminal-green))]" />
+                <CardTitle className="text-lg">Receipt Template</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <button
+                onClick={() => setSelectedTemplate('paragon-fiskalny')}
+                className={cn(
+                  "w-full text-left p-3 rounded-lg border-2 transition-all",
+                  "hover:border-[hsl(var(--terminal-green))]/50",
+                  selectedTemplate === 'paragon-fiskalny'
+                    ? "border-[hsl(var(--terminal-green))] bg-[hsl(var(--terminal-green))]/10"
+                    : "border-muted"
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-mono font-semibold text-sm">Paragon Fiskalny</div>
+                    <div className="text-xs text-muted-foreground">Standard Polish fiscal receipt</div>
+                  </div>
+                  {selectedTemplate === 'paragon-fiskalny' && (
+                    <Check className="h-4 w-4 text-[hsl(var(--terminal-green))]" />
+                  )}
+                </div>
+              </button>
+            </CardContent>
+          </Card>
+
+          {/* Receipt Preview */}
+          <div className="matrix-cascade" style={{ animationDelay: '0.3s' }}>
             <ReceiptPreview receipt={getReceiptData()} taxRates={taxRates} />
           </div>
         </div>

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,0 +1,423 @@
+import { useState, useEffect } from "react";
+import { Printer, Plus, Trash2, ChevronDown, ChevronUp, Store, CheckCircle2, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { InlineSelect } from "@/components/inline-select";
+import { StatusIndicator } from "@/components/status-indicator";
+import { ReceiptPreview } from "@/components/receipt-preview";
+import { cn } from "@/lib/utils";
+import { printerApi, type PrintError } from "@/lib/api";
+import type { ReceiptData, ReceiptItem, TaxRates, StoreInfo, PaymentMethod, TaxCategory } from "@/types/receipt";
+import {
+  getDefaultStore,
+  saveDefaultStore,
+  getTaxRates,
+  calculateSubtotal,
+  createEmptyItem,
+  receiptToContent,
+} from "@/lib/receipt-utils";
+
+export default function Receipts() {
+  // Store info
+  const [store, setStore] = useState<StoreInfo>(getDefaultStore);
+  const [storeExpanded, setStoreExpanded] = useState(true);
+
+  // Tax rates
+  const [taxRates] = useState<TaxRates>(getTaxRates);
+
+  // Line items
+  const [items, setItems] = useState<ReceiptItem[]>([createEmptyItem()]);
+
+  // Payment
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
+  const [cashAmount, setCashAmount] = useState<string>('');
+  const [cardAmount, setCardAmount] = useState<string>('');
+
+  // UI state
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [errorDetails, setErrorDetails] = useState<string | undefined>();
+  const [success, setSuccess] = useState<string | undefined>();
+  const [status, setStatus] = useState<'idle' | 'printing' | 'success' | 'error'>('idle');
+
+  // Auto-save store defaults when changed
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      saveDefaultStore(store);
+    }, 1000);
+    return () => clearTimeout(timeout);
+  }, [store]);
+
+  // Auto-clear success
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => {
+        setSuccess(undefined);
+        setStatus('idle');
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const subtotal = calculateSubtotal(items);
+
+  const updateStore = (field: keyof StoreInfo, value: string) => {
+    setStore(prev => ({ ...prev, [field]: value }));
+  };
+
+  const addItem = () => {
+    setItems(prev => [...prev, createEmptyItem()]);
+  };
+
+  const removeItem = (id: string) => {
+    if (items.length > 1) {
+      setItems(prev => prev.filter(item => item.id !== id));
+    }
+  };
+
+  const updateItem = (id: string, updates: Partial<ReceiptItem>) => {
+    setItems(prev => prev.map(item =>
+      item.id === id ? { ...item, ...updates } : item
+    ));
+  };
+
+  const getReceiptData = (): ReceiptData => ({
+    store,
+    items: items.filter(item => item.name.trim() !== ''),
+    payment: {
+      method: paymentMethod,
+      cashAmount: paymentMethod !== 'card' ? (parseFloat(cashAmount) || subtotal) : undefined,
+      cardAmount: paymentMethod !== 'cash' ? (parseFloat(cardAmount) || subtotal) : undefined,
+    },
+  });
+
+  const handlePrint = async () => {
+    const validItems = items.filter(item => item.name.trim() !== '');
+    if (validItems.length === 0) {
+      setError("[ERROR] Add at least one item with a name");
+      return;
+    }
+
+    setError(undefined);
+    setErrorDetails(undefined);
+    setSuccess(undefined);
+    setLoading(true);
+    setStatus('printing');
+
+    try {
+      const receipt = getReceiptData();
+      const content = receiptToContent(receipt, taxRates);
+
+      await printerApi.printCustom({
+        content,
+        options: {
+          autoCut: true,
+          feedLinesAfterPrint: 3,
+        },
+      });
+
+      setSuccess("[OK] Receipt printed successfully!");
+      setStatus('success');
+    } catch (err) {
+      const printError = err as PrintError;
+      setError(printError.message || "[ERROR] Failed to print");
+      setErrorDetails(printError.details);
+      setStatus('error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearAll = () => {
+    if (confirm("Clear all items?")) {
+      setItems([createEmptyItem()]);
+      setCashAmount('');
+      setCardAmount('');
+    }
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-8 matrix-cascade">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Receipt Generator</h1>
+            <p className="text-muted-foreground mt-2 font-mono text-sm">
+              Generate Polish fiscal receipts (paragon fiskalny)
+            </p>
+          </div>
+          <StatusIndicator status={status} />
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 space-y-6">
+          {/* Store Info */}
+          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.05s' }}>
+            <CardHeader
+              className="cursor-pointer"
+              onClick={() => setStoreExpanded(!storeExpanded)}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Store className="h-5 w-5 text-[hsl(var(--terminal-green))]" />
+                  <CardTitle className="text-lg">Store Information</CardTitle>
+                </div>
+                {storeExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              </div>
+              <CardDescription className="font-mono text-xs">
+                Saved automatically as defaults
+              </CardDescription>
+            </CardHeader>
+            {storeExpanded && (
+              <CardContent className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label className="font-mono text-sm">Store Name</Label>
+                  <Input
+                    value={store.name}
+                    onChange={(e) => updateStore('name', e.target.value)}
+                    placeholder="Store name..."
+                    className="font-mono"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="font-mono text-sm">NIP</Label>
+                  <Input
+                    value={store.nip}
+                    onChange={(e) => updateStore('nip', e.target.value)}
+                    placeholder="1234567890"
+                    className="font-mono"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="font-mono text-sm">Address Line 1</Label>
+                  <Input
+                    value={store.addressLine1}
+                    onChange={(e) => updateStore('addressLine1', e.target.value)}
+                    placeholder="Street address..."
+                    className="font-mono"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="font-mono text-sm">Address Line 2</Label>
+                  <Input
+                    value={store.addressLine2}
+                    onChange={(e) => updateStore('addressLine2', e.target.value)}
+                    placeholder="City, postal code..."
+                    className="font-mono"
+                  />
+                </div>
+              </CardContent>
+            )}
+          </Card>
+
+          {/* Line Items */}
+          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.1s' }}>
+            <CardHeader>
+              <CardTitle className="text-lg font-mono">Line Items</CardTitle>
+              <CardDescription className="font-mono text-xs">
+                Add products or services to the receipt
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {/* Header row */}
+              <div className="grid grid-cols-12 gap-2 text-xs font-mono text-muted-foreground px-1">
+                <div className="col-span-5">Name</div>
+                <div className="col-span-2 text-center">Qty</div>
+                <div className="col-span-2 text-center">Price</div>
+                <div className="col-span-2 text-center">Tax</div>
+                <div className="col-span-1"></div>
+              </div>
+
+              {items.map((item) => (
+                <div key={item.id} className="grid grid-cols-12 gap-2 items-center">
+                  <div className="col-span-5">
+                    <Input
+                      value={item.name}
+                      onChange={(e) => updateItem(item.id, { name: e.target.value })}
+                      placeholder="Item name..."
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                  <div className="col-span-2">
+                    <Input
+                      type="number"
+                      value={item.quantity}
+                      onChange={(e) => updateItem(item.id, { quantity: parseFloat(e.target.value) || 0 })}
+                      min="0"
+                      step="1"
+                      className="font-mono text-sm text-center"
+                    />
+                  </div>
+                  <div className="col-span-2">
+                    <Input
+                      type="number"
+                      value={item.unitPrice || ''}
+                      onChange={(e) => updateItem(item.id, { unitPrice: parseFloat(e.target.value) || 0 })}
+                      min="0"
+                      step="0.01"
+                      placeholder="0,00"
+                      className="font-mono text-sm text-center"
+                    />
+                  </div>
+                  <div className="col-span-2">
+                    <InlineSelect
+                      value={item.taxCategory}
+                      onChange={(value) => updateItem(item.id, { taxCategory: value as TaxCategory })}
+                      options={[
+                        { value: 'A', label: 'A 23%' },
+                        { value: 'B', label: 'B 8%' },
+                        { value: 'C', label: 'C 5%' },
+                        { value: 'D', label: 'D 0%' },
+                      ]}
+                    />
+                  </div>
+                  <div className="col-span-1 flex justify-center">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeItem(item.id)}
+                      disabled={items.length === 1}
+                      className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={addItem}
+                className="w-full font-mono"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add Item
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Totals */}
+          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.15s' }}>
+            <CardHeader>
+              <CardTitle className="text-lg font-mono">Total</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex justify-between items-center text-2xl font-bold font-mono">
+                <span>SUMA PLN</span>
+                <span className="text-[hsl(var(--terminal-green))]">
+                  {subtotal.toFixed(2).replace('.', ',')}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Payment */}
+          <Card className="border-2 matrix-cascade" style={{ animationDelay: '0.2s' }}>
+            <CardHeader>
+              <CardTitle className="text-lg font-mono">Payment</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="font-mono text-sm">Payment Method</Label>
+                <InlineSelect
+                  value={paymentMethod}
+                  onChange={(value) => setPaymentMethod(value as PaymentMethod)}
+                  options={[
+                    { value: 'cash', label: 'Cash' },
+                    { value: 'card', label: 'Card' },
+                    { value: 'mixed', label: 'Mixed' },
+                  ]}
+                />
+              </div>
+
+              {paymentMethod === 'mixed' && (
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label className="font-mono text-sm">Cash Amount</Label>
+                    <Input
+                      type="number"
+                      value={cashAmount}
+                      onChange={(e) => setCashAmount(e.target.value)}
+                      placeholder={subtotal.toFixed(2)}
+                      className="font-mono"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="font-mono text-sm">Card Amount</Label>
+                    <Input
+                      type="number"
+                      value={cardAmount}
+                      onChange={(e) => setCardAmount(e.target.value)}
+                      placeholder="0.00"
+                      className="font-mono"
+                    />
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Messages */}
+          {success && (
+            <Alert variant="success" className="paper-feed">
+              <CheckCircle2 className="h-4 w-4" />
+              <AlertDescription className="glow-green">
+                {success}
+              </AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                <div className="font-bold">{error}</div>
+                {errorDetails && (
+                  <div className="text-xs mt-1 opacity-90">{errorDetails}</div>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* Actions */}
+          <div className="flex flex-wrap gap-3 pb-6">
+            <Button
+              onClick={handlePrint}
+              disabled={loading}
+              size="lg"
+              className={cn(
+                "border-2 transition-all font-mono",
+                "border-[hsl(var(--terminal-green))] bg-[hsl(var(--terminal-green))]/10 text-[hsl(var(--terminal-green))]",
+                "hover:bg-[hsl(var(--terminal-green))]/20 hover:box-glow-green",
+                loading && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              <Printer className="mr-2 h-5 w-5" />
+              {loading ? "PRINTING..." : "PRINT RECEIPT"}
+            </Button>
+            <Button
+              onClick={clearAll}
+              variant="outline"
+              size="lg"
+              className="font-mono text-destructive border-destructive/50 hover:bg-destructive/10"
+            >
+              <Trash2 className="mr-2 h-5 w-5" />
+              Clear Items
+            </Button>
+          </div>
+        </div>
+
+        {/* Right Sidebar - Preview */}
+        <div className="lg:col-span-1 space-y-6">
+          <div className="matrix-cascade" style={{ animationDelay: '0.25s' }}>
+            <ReceiptPreview receipt={getReceiptData()} taxRates={taxRates} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -3,7 +3,8 @@
 export interface StoreInfo {
   name: string;
   addressLine1: string;
-  addressLine2: string;
+  city: string;
+  zipCode: string;
   nip: string;
 }
 
@@ -57,10 +58,11 @@ export const DEFAULT_TAX_RATES: TaxRates = {
 };
 
 export const DEFAULT_STORE: StoreInfo = {
-  name: '',
-  addressLine1: '',
-  addressLine2: '',
-  nip: '',
+  name: 'Sklep u Janusza',
+  addressLine1: 'ul. Świętego Mikołaja 42',
+  city: 'Pcim Dolny',
+  zipCode: '69-420',
+  nip: '1234567890',
 };
 
 export const TAX_CATEGORY_LABELS: Record<TaxCategory, string> = {

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -1,0 +1,71 @@
+// Receipt generator types
+
+export interface StoreInfo {
+  name: string;
+  addressLine1: string;
+  addressLine2: string;
+  nip: string;
+}
+
+export interface ReceiptItem {
+  id: string;
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  taxCategory: TaxCategory;
+}
+
+export type TaxCategory = 'A' | 'B' | 'C' | 'D';
+
+export interface TaxRates {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+}
+
+export type PaymentMethod = 'cash' | 'card' | 'mixed';
+
+export interface Payment {
+  method: PaymentMethod;
+  cashAmount?: number;
+  cardAmount?: number;
+}
+
+export interface ReceiptData {
+  store: StoreInfo;
+  items: ReceiptItem[];
+  payment: Payment;
+  title?: string;
+  documentNumber?: string;
+  date?: string;
+}
+
+export interface TaxBreakdownLine {
+  category: TaxCategory;
+  rate: number;
+  base: number;
+  tax: number;
+}
+
+// Default values
+export const DEFAULT_TAX_RATES: TaxRates = {
+  A: 23,
+  B: 8,
+  C: 5,
+  D: 0,
+};
+
+export const DEFAULT_STORE: StoreInfo = {
+  name: '',
+  addressLine1: '',
+  addressLine2: '',
+  nip: '',
+};
+
+export const TAX_CATEGORY_LABELS: Record<TaxCategory, string> = {
+  A: 'PTU A (23%)',
+  B: 'PTU B (8%)',
+  C: 'PTU C (5%)',
+  D: 'PTU D (0%)',
+};


### PR DESCRIPTION
## Summary
- Add dedicated receipt generator page (`/receipts`) for Polish fiscal receipts
- Support for store info, line items with tax categories (A/B/C/D), payment methods
- Live receipt preview matching actual print output
- Same-line left-right alignment for receipt formatting
- Polish character support via PC852 encoding (ó, ł, ć, ą, ę, ź, ż, ń, ś)
- Funny Polish defaults (Sklep u Janusza, Pcim Dolny, 69-420)

## Test plan
- [ ] Navigate to `/receipts`
- [ ] Add items with Polish names containing special characters
- [ ] Verify preview shows correct formatting
- [ ] Print receipt and verify Polish characters display correctly
- [ ] Test payment methods (cash/card/mixed)

🤖 Generated with [Claude Code](https://claude.ai/code)