### PR TITLE
feat: add Biedronka receipt template

### DIFF
--- a/frontend/src/components/receipt-preview.tsx
+++ b/frontend/src/components/receipt-preview.tsx
@@ -21,12 +21,12 @@ interface ReceiptPreviewProps {
 export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
   const [isExpanded, setIsExpanded] = useState(true);
 
-  const { store, items, payment, title, date } = receipt;
+  const { store, items, payment, title, date, template } = receipt;
   const subtotal = calculateSubtotal(items);
   const breakdown = calculateTaxBreakdown(items, taxRates);
   const totalTax = calculateTotalTax(breakdown);
-
-  // Always show preview
+  const isBiedronka = template === 'biedronka';
+  const displayDate = date || formatDate();
 
   return (
     <Card className="overflow-hidden border-2">
@@ -44,113 +44,237 @@ export function ReceiptPreview({ receipt, taxRates }: ReceiptPreviewProps) {
       {isExpanded && (
         <div className="p-4 border-t-2">
           <div className="receipt-paper perforated-top rounded-lg shadow-lg p-4 max-w-[320px] mx-auto font-mono text-sm bg-white text-black">
-            {/* Header */}
-            <div className="text-center space-y-0.5">
-              {store.name && (
-                <div className="font-bold text-base tracking-wide">{store.name}</div>
-              )}
-              {store.addressLine1 && <div>{store.addressLine1}</div>}
-              {(store.city || store.zipCode) && <div>{store.zipCode} {store.city}</div>}
-              {store.nip && <div>NIP: {store.nip}</div>}
-            </div>
+            {isBiedronka ? (
+              // Biedronka template
+              <>
+                {/* Header - Biedronka style */}
+                <div className="text-center space-y-0.5">
+                  <div className="font-bold text-base tracking-wide">Biedronka</div>
+                  <div className="text-xs">Codziennie niskie ceny</div>
+                </div>
 
-            {/* Title */}
-            <div className="my-3 text-center">
-              <div className="font-bold text-lg tracking-widest">
-                {title || 'PARAGON FISKALNY'}
-              </div>
-            </div>
+                <div className="text-center space-y-0.5 mt-2 text-xs">
+                  <div>
+                    {store.storeNumber ? `Sklep ${store.storeNumber} ` : ''}{store.addressLine1}
+                  </div>
+                  <div>{store.zipCode} {store.city}</div>
+                  {store.parentCompany && <div>{store.parentCompany}</div>}
+                  {store.parentAddress && <div>{store.parentAddress}</div>}
+                  <div>NIP {store.nip}</div>
+                </div>
 
-            <div className="border-t border-dashed border-gray-400 my-2" />
+                {/* Date line */}
+                <div className="flex justify-between text-xs mt-2">
+                  <span>{displayDate}</span>
+                  <span>222162</span>
+                </div>
 
-            {/* Line items */}
-            {items.length > 0 && (
-              <div className="space-y-1">
-                {items.map((item) => {
-                  const total = calculateItemTotal(item);
-                  const name = item.name || '(no name)';
-                  const priceStr = `${formatQuantity(item.quantity)} SZT * ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`;
-                  const fitsOneLine = name.length + priceStr.length + 1 <= CHARS_PER_LINE.normal;
+                {/* Title */}
+                <div className="my-2 text-center">
+                  <div className="font-bold">PARAGON FISKALNY</div>
+                </div>
 
-                  return fitsOneLine ? (
-                    <div key={item.id} className="flex justify-between text-xs">
-                      <span className="truncate">{name}</span>
-                      <span className="ml-2 whitespace-nowrap">{priceStr}</span>
-                    </div>
-                  ) : (
-                    <div key={item.id}>
-                      <div className="truncate text-xs">{name}</div>
-                      <div className="text-right text-xs">{priceStr}</div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+                {/* Line items - Biedronka format */}
+                {items.length > 0 && (
+                  <div className="space-y-1">
+                    {items.map((item) => {
+                      const total = calculateItemTotal(item) - (item.discount || 0);
+                      const name = item.name || '(no name)';
 
-            {items.length === 0 && (
-              <div className="text-center text-gray-400 py-2">No items</div>
-            )}
+                      return (
+                        <div key={item.id} className="text-xs">
+                          <div className="flex justify-between">
+                            <span className="truncate">{name}</span>
+                            <span>{item.taxCategory}</span>
+                          </div>
+                          <div className="text-right">
+                            {formatQuantity(item.quantity)} x{formatCurrency(item.unitPrice)} {formatCurrency(total)}{item.taxCategory}
+                          </div>
+                          {item.discount && item.discount > 0 && (
+                            <>
+                              <div className="flex justify-between">
+                                <span className="pl-4">Rabat</span>
+                                <span>-{formatCurrency(item.discount)}</span>
+                              </div>
+                              <div className="text-right">{formatCurrency(total)}{item.taxCategory}</div>
+                            </>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
 
-            <div className="border-t border-dashed border-gray-400 my-2" />
+                {items.length === 0 && (
+                  <div className="text-center text-gray-400 py-2">No items</div>
+                )}
 
-            {/* Tax breakdown */}
-            {breakdown.length > 0 && (
-              <div className="space-y-0.5 text-xs">
-                {breakdown.map((line) => (
-                  <div key={line.category}>
+                <div className="border-t border-dotted border-gray-400 my-2" />
+
+                {/* Tax breakdown - Biedronka style */}
+                {breakdown.length > 0 && (
+                  <div className="space-y-0.5 text-xs">
+                    {breakdown.map((line) => {
+                      const gross = line.base + line.tax;
+                      return (
+                        <div key={line.category}>
+                          <div className="flex justify-between">
+                            <span>SPRZEDAŻ OPODATKOWANA {line.category}</span>
+                            <span>{formatCurrency(gross)}</span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span>PTU {line.category} {line.rate},00 %</span>
+                            <span>{formatCurrency(line.tax)}</span>
+                          </div>
+                        </div>
+                      );
+                    })}
                     <div className="flex justify-between">
-                      <span>Sp.op.{line.category}</span>
-                      <span>{formatCurrency(line.base)}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>PTU {line.category}={line.rate},00%</span>
-                      <span>{formatCurrency(line.tax)}</span>
+                      <span>SUMA PTU</span>
+                      <span>{formatCurrency(totalTax)}</span>
                     </div>
                   </div>
-                ))}
-                <div className="flex justify-between font-semibold">
-                  <span>SUMA PTU</span>
-                  <span>{formatCurrency(totalTax)}</span>
+                )}
+
+                {/* Total */}
+                <div className="flex justify-between font-bold text-lg mt-2">
+                  <span>SUMA PLN</span>
+                  <span>{formatCurrency(subtotal)}</span>
                 </div>
-              </div>
+
+                {/* Footer */}
+                <div className="text-xs mt-2 space-y-1">
+                  <div className="flex justify-between">
+                    <span>00049 #Kasa 3 Kasjer nr 9</span>
+                    <span>{displayDate}</span>
+                  </div>
+                  <div className="text-center text-[10px] break-all">
+                    FA7DF8F64F93123AB227453F5827CBBAF0B4ACBA
+                  </div>
+                  <div className="text-center">CCH 1701372836</div>
+                  <div className="text-center mt-2 py-2 border-2 border-black">
+                    <div className="text-xs">||||||||||||||||||||||||</div>
+                    <div className="text-[10px]">Nr sys. 9950</div>
+                  </div>
+                </div>
+
+                {/* Cut line */}
+                <div className="text-center text-xs opacity-40 mt-4">
+                  ✂ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ✂
+                </div>
+              </>
+            ) : (
+              // Standard Paragon Fiskalny template
+              <>
+                {/* Header */}
+                <div className="text-center space-y-0.5">
+                  {store.name && (
+                    <div className="font-bold text-base tracking-wide">{store.name}</div>
+                  )}
+                  {store.addressLine1 && <div>{store.addressLine1}</div>}
+                  {(store.city || store.zipCode) && <div>{store.zipCode} {store.city}</div>}
+                  {store.nip && <div>NIP: {store.nip}</div>}
+                </div>
+
+                {/* Title */}
+                <div className="my-3 text-center">
+                  <div className="font-bold text-lg tracking-widest">
+                    {title || 'PARAGON FISKALNY'}
+                  </div>
+                </div>
+
+                <div className="border-t border-dashed border-gray-400 my-2" />
+
+                {/* Line items */}
+                {items.length > 0 && (
+                  <div className="space-y-1">
+                    {items.map((item) => {
+                      const total = calculateItemTotal(item);
+                      const name = item.name || '(no name)';
+                      const priceStr = `${formatQuantity(item.quantity)} SZT * ${formatCurrency(item.unitPrice)} = ${formatCurrency(total)} ${item.taxCategory}`;
+                      const fitsOneLine = name.length + priceStr.length + 1 <= CHARS_PER_LINE.normal;
+
+                      return fitsOneLine ? (
+                        <div key={item.id} className="flex justify-between text-xs">
+                          <span className="truncate">{name}</span>
+                          <span className="ml-2 whitespace-nowrap">{priceStr}</span>
+                        </div>
+                      ) : (
+                        <div key={item.id}>
+                          <div className="truncate text-xs">{name}</div>
+                          <div className="text-right text-xs">{priceStr}</div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {items.length === 0 && (
+                  <div className="text-center text-gray-400 py-2">No items</div>
+                )}
+
+                <div className="border-t border-dashed border-gray-400 my-2" />
+
+                {/* Tax breakdown */}
+                {breakdown.length > 0 && (
+                  <div className="space-y-0.5 text-xs">
+                    {breakdown.map((line) => (
+                      <div key={line.category}>
+                        <div className="flex justify-between">
+                          <span>Sp.op.{line.category}</span>
+                          <span>{formatCurrency(line.base)}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span>PTU {line.category}={line.rate},00%</span>
+                          <span>{formatCurrency(line.tax)}</span>
+                        </div>
+                      </div>
+                    ))}
+                    <div className="flex justify-between font-semibold">
+                      <span>SUMA PTU</span>
+                      <span>{formatCurrency(totalTax)}</span>
+                    </div>
+                  </div>
+                )}
+
+                <div className="border-t border-dashed border-gray-400 my-2" />
+
+                {/* Total */}
+                <div className="flex justify-between font-bold text-lg">
+                  <span>SUMA PLN</span>
+                  <span>{formatCurrency(subtotal)}</span>
+                </div>
+
+                <div className="border-t border-dashed border-gray-400 my-2" />
+
+                {/* Payment */}
+                <div className="text-center text-xs mb-1">ROZLICZENIE PLATNOSCI</div>
+                <div className="space-y-0.5 text-xs">
+                  {(payment.method === 'cash' || payment.method === 'mixed') && (
+                    <div className="flex justify-between">
+                      <span>ZAPLACONO GOTOWKA PLN</span>
+                      <span>{formatCurrency(payment.cashAmount ?? (payment.method === 'cash' ? subtotal : 0))}</span>
+                    </div>
+                  )}
+                  {(payment.method === 'card' || payment.method === 'mixed') && (
+                    <div className="flex justify-between">
+                      <span>ZAPLACONO KARTA PLN</span>
+                      <span>{formatCurrency(payment.cardAmount ?? (payment.method === 'card' ? subtotal : 0))}</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Date */}
+                <div className="text-center text-xs mt-3">
+                  {displayDate}
+                </div>
+
+                {/* Cut line */}
+                <div className="text-center text-xs opacity-40 mt-4">
+                  ✂ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ✂
+                </div>
+              </>
             )}
-
-            <div className="border-t border-dashed border-gray-400 my-2" />
-
-            {/* Total */}
-            <div className="flex justify-between font-bold text-lg">
-              <span>SUMA PLN</span>
-              <span>{formatCurrency(subtotal)}</span>
-            </div>
-
-            <div className="border-t border-dashed border-gray-400 my-2" />
-
-            {/* Payment */}
-            <div className="text-center text-xs mb-1">ROZLICZENIE PLATNOSCI</div>
-            <div className="space-y-0.5 text-xs">
-              {(payment.method === 'cash' || payment.method === 'mixed') && (
-                <div className="flex justify-between">
-                  <span>ZAPLACONO GOTOWKA PLN</span>
-                  <span>{formatCurrency(payment.cashAmount ?? (payment.method === 'cash' ? subtotal : 0))}</span>
-                </div>
-              )}
-              {(payment.method === 'card' || payment.method === 'mixed') && (
-                <div className="flex justify-between">
-                  <span>ZAPLACONO KARTA PLN</span>
-                  <span>{formatCurrency(payment.cardAmount ?? (payment.method === 'card' ? subtotal : 0))}</span>
-                </div>
-              )}
-            </div>
-
-            {/* Date */}
-            <div className="text-center text-xs mt-3">
-              {date || formatDate()}
-            </div>
-
-            {/* Cut line */}
-            <div className="text-center text-xs opacity-40 mt-4">
-              ✂ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ✂
-            </div>
           </div>
         </div>
       )}

--- a/frontend/src/lib/receipt-utils.ts
+++ b/frontend/src/lib/receipt-utils.ts
@@ -279,3 +279,192 @@ export function createEmptyItem(): ReceiptItem {
     taxCategory: 'A',
   };
 }
+
+// Biedronka-style receipt format
+export function biedronkaReceiptToContent(receipt: ReceiptData, taxRates: TaxRates): PrintContent[] {
+  const content: PrintContent[] = [];
+  const { store, items, date, kasaNumber, kasjerNumber } = receipt;
+
+  // Header - Biedronka style
+  content.push({
+    type: ContentType.Text,
+    content: 'Biedronka',
+    alignment: Alignment.Center,
+    style: [PrintStyle.Bold, PrintStyle.DoubleWidth],
+  });
+  content.push({
+    type: ContentType.Text,
+    content: 'Codziennie niskie ceny',
+    alignment: Alignment.Center,
+  });
+  content.push({ type: ContentType.LineFeed, lines: 1 });
+
+  // Store address
+  const storeNumStr = store.storeNumber ? `Sklep ${store.storeNumber} ` : '';
+  content.push({
+    type: ContentType.Text,
+    content: `${storeNumStr}${store.addressLine1}`,
+    alignment: Alignment.Center,
+  });
+  content.push({
+    type: ContentType.Text,
+    content: `${store.zipCode} ${store.city}`,
+    alignment: Alignment.Center,
+  });
+
+  // Parent company
+  if (store.parentCompany) {
+    content.push({
+      type: ContentType.Text,
+      content: store.parentCompany,
+      alignment: Alignment.Center,
+    });
+  }
+  if (store.parentAddress) {
+    content.push({
+      type: ContentType.Text,
+      content: store.parentAddress,
+      alignment: Alignment.Center,
+    });
+  }
+
+  // NIP
+  content.push({
+    type: ContentType.Text,
+    content: `NIP ${store.nip}`,
+    alignment: Alignment.Center,
+  });
+
+  content.push({ type: ContentType.LineFeed, lines: 1 });
+
+  // Date and receipt number line
+  const receiptNum = Math.floor(Math.random() * 900000 + 100000).toString();
+  const dateStr = date || formatDate();
+  content.push({
+    type: ContentType.Text,
+    content: formatLine(dateStr, receiptNum),
+  });
+
+  // PARAGON FISKALNY
+  content.push({
+    type: ContentType.Text,
+    content: 'PARAGON FISKALNY',
+    alignment: Alignment.Center,
+    style: [PrintStyle.Bold],
+  });
+
+  // Items - Biedronka format
+  for (const item of items) {
+    const total = calculateItemTotal(item) - (item.discount || 0);
+
+    // First line: name + tax category
+    const nameLine = formatLine(item.name, item.taxCategory);
+    content.push({
+      type: ContentType.Text,
+      content: nameLine,
+    });
+
+    // Second line: qty x price = total + tax category
+    const qtyStr = formatQuantity(item.quantity);
+    const priceStr = formatCurrency(item.unitPrice);
+    const totalStr = formatCurrency(total);
+    const priceLine = `${qtyStr} x${priceStr} ${totalStr}${item.taxCategory}`;
+    content.push({
+      type: ContentType.Text,
+      content: priceLine,
+      alignment: Alignment.Right,
+    });
+
+    // Rabat line if discount exists
+    if (item.discount && item.discount > 0) {
+      content.push({
+        type: ContentType.Text,
+        content: formatLine('   Rabat', `-${formatCurrency(item.discount)}`),
+      });
+      const afterDiscount = total;
+      content.push({
+        type: ContentType.Text,
+        content: formatLine('', `${formatCurrency(afterDiscount)}${item.taxCategory}`),
+      });
+    }
+  }
+
+  content.push({ type: ContentType.Separator, separatorChar: '.', separatorLength: 42 });
+
+  // Tax breakdown - Biedronka style
+  const breakdown = calculateTaxBreakdown(items, taxRates);
+  for (const line of breakdown) {
+    const grossAmount = line.base + line.tax;
+    content.push({
+      type: ContentType.Text,
+      content: formatLine(`SPRZEDAŻ OPODATKOWANA ${line.category}`, formatCurrency(grossAmount)),
+    });
+    content.push({
+      type: ContentType.Text,
+      content: formatLine(`PTU ${line.category} ${line.rate},00 %`, formatCurrency(line.tax)),
+    });
+  }
+
+  const totalTax = calculateTotalTax(breakdown);
+  content.push({
+    type: ContentType.Text,
+    content: formatLine('SUMA PTU', formatCurrency(totalTax)),
+  });
+
+  // Total
+  const totalAfterDiscount = items.reduce((sum, item) => sum + calculateItemTotal(item) - (item.discount || 0), 0);
+  content.push({
+    type: ContentType.Text,
+    content: formatLine('SUMA PLN', formatCurrency(totalAfterDiscount), CHARS_PER_LINE.doubleWidth),
+    style: [PrintStyle.Bold, PrintStyle.DoubleHeight, PrintStyle.DoubleWidth],
+  });
+
+  // Footer - Kasa/Kasjer info
+  const kasa = kasaNumber || '3';
+  const kasjer = kasjerNumber || '9';
+  const footerNum = Math.floor(Math.random() * 90000 + 10000).toString().padStart(5, '0');
+  content.push({
+    type: ContentType.Text,
+    content: formatLine(`${footerNum} #Kasa ${kasa} Kasjer nr ${kasjer}`, dateStr),
+  });
+
+  // Fiscal code (random hex)
+  const fiscalCode = Array.from({ length: 40 }, () =>
+    '0123456789ABCDEF'[Math.floor(Math.random() * 16)]
+  ).join('');
+  content.push({
+    type: ContentType.Text,
+    content: fiscalCode,
+    alignment: Alignment.Center,
+    style: [PrintStyle.FontB],
+  });
+
+  // CCH number
+  const cchNum = Math.floor(Math.random() * 9000000000 + 1000000000).toString();
+  content.push({
+    type: ContentType.Text,
+    content: `CCH ${cchNum}`,
+    alignment: Alignment.Center,
+  });
+
+  // Barcode
+  const barcode = '1000043879950072203475';
+  content.push({
+    type: ContentType.Barcode,
+    content: barcode,
+    barcodeOptions: { type: 'CODE128', width: 'Default', heightInDots: 60 },
+  });
+
+  // Nr sys
+  content.push({
+    type: ContentType.Text,
+    content: 'Nr sys. 9950',
+    alignment: Alignment.Center,
+  });
+
+  // Feed and cut
+  content.push({ type: ContentType.LineFeed, lines: 3 });
+  content.push({ type: ContentType.Cut });
+
+  return content;
+}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -9,7 +9,8 @@ import { StatusIndicator } from "@/components/status-indicator";
 import { ReceiptPreview } from "@/components/receipt-preview";
 import { cn } from "@/lib/utils";
 import { printerApi, type PrintError } from "@/lib/api";
-import type { ReceiptData, ReceiptItem, TaxRates, StoreInfo, PaymentMethod, TaxCategory } from "@/types/receipt";
+import type { ReceiptData, ReceiptItem, TaxRates, StoreInfo, PaymentMethod, TaxCategory, ReceiptTemplate } from "@/types/receipt";
+import { BIEDRONKA_STORE } from "@/types/receipt";
 import {
   getDefaultStore,
   saveDefaultStore,
@@ -17,6 +18,7 @@ import {
   calculateSubtotal,
   createEmptyItem,
   receiptToContent,
+  biedronkaReceiptToContent,
 } from "@/lib/receipt-utils";
 
 export default function Receipts() {
@@ -36,7 +38,17 @@ export default function Receipts() {
   const [cardAmount, setCardAmount] = useState<string>('');
 
   // Template selection
-  const [selectedTemplate, setSelectedTemplate] = useState<string>('paragon-fiskalny');
+  const [selectedTemplate, setSelectedTemplate] = useState<ReceiptTemplate>('paragon-fiskalny');
+
+  // Handle template change - switch store defaults
+  const handleTemplateChange = (template: ReceiptTemplate) => {
+    setSelectedTemplate(template);
+    if (template === 'biedronka') {
+      setStore(BIEDRONKA_STORE);
+    } else {
+      setStore(getDefaultStore());
+    }
+  };
 
   // UI state
   const [loading, setLoading] = useState(false);
@@ -94,6 +106,7 @@ export default function Receipts() {
       cashAmount: paymentMethod !== 'card' ? (parseFloat(cashAmount) || subtotal) : undefined,
       cardAmount: paymentMethod !== 'cash' ? (parseFloat(cardAmount) || subtotal) : undefined,
     },
+    template: selectedTemplate,
   });
 
   const handlePrint = async () => {
@@ -111,7 +124,9 @@ export default function Receipts() {
 
     try {
       const receipt = getReceiptData();
-      const content = receiptToContent(receipt, taxRates);
+      const content = selectedTemplate === 'biedronka'
+        ? biedronkaReceiptToContent(receipt, taxRates)
+        : receiptToContent(receipt, taxRates);
 
       await printerApi.printCustom({
         content,
@@ -177,7 +192,18 @@ export default function Receipts() {
             </CardHeader>
             {storeExpanded && (
               <CardContent className="grid gap-3 sm:grid-cols-4">
-                <div className="sm:col-span-2 space-y-1">
+                {selectedTemplate === 'biedronka' && (
+                  <div className="space-y-1">
+                    <Label className="font-mono text-xs text-muted-foreground">Store #</Label>
+                    <Input
+                      value={store.storeNumber || ''}
+                      onChange={(e) => updateStore('storeNumber', e.target.value)}
+                      placeholder="4387"
+                      className="font-mono h-9"
+                    />
+                  </div>
+                )}
+                <div className={cn("space-y-1", selectedTemplate === 'biedronka' ? "sm:col-span-1" : "sm:col-span-2")}>
                   <Label className="font-mono text-xs text-muted-foreground">Store Name</Label>
                   <Input
                     value={store.name}
@@ -222,6 +248,28 @@ export default function Receipts() {
                     className="font-mono h-9"
                   />
                 </div>
+                {selectedTemplate === 'biedronka' && (
+                  <>
+                    <div className="sm:col-span-2 space-y-1">
+                      <Label className="font-mono text-xs text-muted-foreground">Parent Company</Label>
+                      <Input
+                        value={store.parentCompany || ''}
+                        onChange={(e) => updateStore('parentCompany', e.target.value)}
+                        placeholder="Jeronimo Martins Polska S.A."
+                        className="font-mono h-9"
+                      />
+                    </div>
+                    <div className="sm:col-span-2 space-y-1">
+                      <Label className="font-mono text-xs text-muted-foreground">Parent Address</Label>
+                      <Input
+                        value={store.parentAddress || ''}
+                        onChange={(e) => updateStore('parentAddress', e.target.value)}
+                        placeholder="ul. Żniwna 5, 62-025 Kostrzyn"
+                        className="font-mono h-9"
+                      />
+                    </div>
+                  </>
+                )}
               </CardContent>
             )}
           </Card>
@@ -425,7 +473,7 @@ export default function Receipts() {
             </CardHeader>
             <CardContent className="space-y-2">
               <button
-                onClick={() => setSelectedTemplate('paragon-fiskalny')}
+                onClick={() => handleTemplateChange('paragon-fiskalny')}
                 className={cn(
                   "w-full text-left p-3 rounded-lg border-2 transition-all",
                   "hover:border-[hsl(var(--terminal-green))]/50",
@@ -440,6 +488,26 @@ export default function Receipts() {
                     <div className="text-xs text-muted-foreground">Standard Polish fiscal receipt</div>
                   </div>
                   {selectedTemplate === 'paragon-fiskalny' && (
+                    <Check className="h-4 w-4 text-[hsl(var(--terminal-green))]" />
+                  )}
+                </div>
+              </button>
+              <button
+                onClick={() => handleTemplateChange('biedronka')}
+                className={cn(
+                  "w-full text-left p-3 rounded-lg border-2 transition-all",
+                  "hover:border-[hsl(var(--terminal-green))]/50",
+                  selectedTemplate === 'biedronka'
+                    ? "border-[hsl(var(--terminal-green))] bg-[hsl(var(--terminal-green))]/10"
+                    : "border-muted"
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-mono font-semibold text-sm">Biedronka</div>
+                    <div className="text-xs text-muted-foreground">Codziennie niskie ceny</div>
+                  </div>
+                  {selectedTemplate === 'biedronka' && (
                     <Check className="h-4 w-4 text-[hsl(var(--terminal-green))]" />
                   )}
                 </div>

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -6,7 +6,13 @@ export interface StoreInfo {
   city: string;
   zipCode: string;
   nip: string;
+  // Biedronka-specific: parent company info
+  parentCompany?: string;
+  parentAddress?: string;
+  storeNumber?: string;
 }
+
+export type ReceiptTemplate = 'paragon-fiskalny' | 'biedronka';
 
 export interface ReceiptItem {
   id: string;
@@ -14,6 +20,7 @@ export interface ReceiptItem {
   quantity: number;
   unitPrice: number;
   taxCategory: TaxCategory;
+  discount?: number; // Rabat amount
 }
 
 export type TaxCategory = 'A' | 'B' | 'C' | 'D';
@@ -37,9 +44,13 @@ export interface ReceiptData {
   store: StoreInfo;
   items: ReceiptItem[];
   payment: Payment;
+  template?: ReceiptTemplate;
   title?: string;
   documentNumber?: string;
   date?: string;
+  // Biedronka-specific footer
+  kasaNumber?: string;
+  kasjerNumber?: string;
 }
 
 export interface TaxBreakdownLine {
@@ -63,6 +74,17 @@ export const DEFAULT_STORE: StoreInfo = {
   city: 'Pcim Dolny',
   zipCode: '69-420',
   nip: '1234567890',
+};
+
+export const BIEDRONKA_STORE: StoreInfo = {
+  name: 'Biedronka',
+  storeNumber: '4387',
+  addressLine1: 'ul. Ks. Czesława Majorka 1',
+  city: 'Ostrów Wielkopolski',
+  zipCode: '63-400',
+  parentCompany: 'Jeronimo Martins Polska S.A.',
+  parentAddress: 'ul. Żniwna 5, 62-025 Kostrzyn',
+  nip: '779-10-11-327',
 };
 
 export const TAX_CATEGORY_LABELS: Record<TaxCategory, string> = {


### PR DESCRIPTION
## Summary
- Add Biedronka supermarket receipt template alongside existing Paragon Fiskalny
- Template selector UI switches store defaults automatically
- Biedronka format includes parent company info, fiscal codes, and CODE128 barcode

## Test plan
- [x] Select Biedronka template, verify store fields update
- [x] Add items and verify preview shows Biedronka layout
- [x] Print receipt and verify format matches real Biedronka receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)