### PR TITLE
feat: native MCP server at /mcp (#12)

### DIFF
--- a/backend/Controllers/PrinterController.cs
+++ b/backend/Controllers/PrinterController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using ThermalPrinterWeb.Models;
 using ThermalPrinterWeb.Services;
+using ThermalPrinterWeb.Services.Printing;
 
 namespace ThermalPrinterWeb.Controllers;
 
@@ -24,7 +25,7 @@ public class PrinterController(ILogger<PrinterController> logger, IPrinterServic
         }
         else if (!string.IsNullOrEmpty(request.Name) && !string.IsNullOrEmpty(request.Message))
         {
-            content = BuildSimpleContent(request.Name, request.Message, request.ImageBase64);
+            content = SimpleNote.Build(request.Name, request.Message, request.ImageBase64);
         }
         else
         {
@@ -49,44 +50,5 @@ public class PrinterController(ILogger<PrinterController> logger, IPrinterServic
             "Printer status requested: ready={Ready} ({Reason})",
             status.Ready, status.NotReadyReason ?? "ok");
         return status.Reachable ? Ok(status) : StatusCode(503, status);
-    }
-
-    private static List<PrintContent> BuildSimpleContent(string name, string message, string? imageBase64)
-    {
-        var content = new List<PrintContent>
-        {
-            new() { Type = ContentType.Separator, SeparatorChar = "=", SeparatorLength = 32 },
-            new()
-            {
-                Type = ContentType.Text,
-                Content = name,
-                Alignment = Alignment.Center,
-                Style = [PrintStyle.DoubleWidth, PrintStyle.DoubleHeight]
-            },
-            new() { Type = ContentType.Separator },
-            new()
-            {
-                Type = ContentType.Text,
-                Content = message,
-                Alignment = Alignment.Center
-            },
-            new() { Type = ContentType.Separator }
-        };
-
-        if (!string.IsNullOrEmpty(imageBase64))
-        {
-            content.Add(new PrintContent
-            {
-                Type = ContentType.Image,
-                Content = imageBase64,
-                ImageOptions = new ImageOptions { MaxWidth = 500, MaxHeight = 500 }
-            });
-            content.Add(new() { Type = ContentType.Separator });
-        }
-
-        content.Add(new() { Type = ContentType.LineFeed, Lines = 3 });
-        content.Add(new() { Type = ContentType.Cut });
-
-        return content;
     }
 }

--- a/backend/Mcp/PrinterTools.cs
+++ b/backend/Mcp/PrinterTools.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using ThermalPrinterWeb.Models;
+using ThermalPrinterWeb.Services;
+using ThermalPrinterWeb.Services.Printing;
+
+namespace ThermalPrinterWeb.Mcp;
+
+// Public on purpose: WithToolsFromAssembly() discovers tools by reflecting over
+// public [McpServerToolType] classes / [McpServerTool] methods. IPrinterService
+// is injected from the request's DI scope; the remaining parameters form each
+// tool's input schema.
+[McpServerToolType]
+public static class PrinterTools
+{
+    [McpServerTool(Name = "get_status")]
+    [Description("Read the thermal printer's live status (reachable, online, cover open, paper out). Call before printing so a job is not rejected.")]
+    public static async Task<PrinterStatus> GetStatusAsync(IPrinterService printer)
+        => await printer.GetStatusAsync();
+
+    [McpServerTool(Name = "print_note")]
+    [Description("Print a simple note: a large centered title, a message below it, an optional image, then a cut. Best for quick notes and messages.")]
+    public static async Task<string> PrintNoteAsync(
+        IPrinterService printer,
+        [Description("Title, printed large and centered at the top.")] string title,
+        [Description("Message body, printed centered under the title.")] string message,
+        [Description("Optional base64-encoded PNG to print under the message.")] string? imageBase64 = null)
+    {
+        var result = await printer.PrintAsync(SimpleNote.Build(title, message, imageBase64));
+        return result.Success ? "Printed." : $"Not printed: {result.Error}";
+    }
+
+    [McpServerTool(Name = "print")]
+    [Description("Print a custom document: an ordered list of content blocks (Text, Image, Barcode, QRCode, LineFeed, Cut, Separator, CodePage). Use for full control over styling, barcodes, QR codes and images.")]
+    public static async Task<string> PrintAsync(
+        IPrinterService printer,
+        [Description("Ordered content blocks to print, top to bottom.")] List<PrintContent> content,
+        [Description("Optional print options: code page, line spacing, auto-cut.")] PrintOptions? options = null)
+    {
+        var result = await printer.PrintAsync(content, options);
+        return result.Success ? "Printed." : $"Not printed: {result.Error}";
+    }
+}

--- a/backend/Models/Enums/Alignment.cs
+++ b/backend/Models/Enums/Alignment.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum Alignment
 {
     Left,

--- a/backend/Models/Enums/BarLabelPosition.cs
+++ b/backend/Models/Enums/BarLabelPosition.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BarLabelPosition
 {
     None,

--- a/backend/Models/Enums/BarWidth.cs
+++ b/backend/Models/Enums/BarWidth.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BarWidth
 {
     Thin,

--- a/backend/Models/Enums/BarcodeType.cs
+++ b/backend/Models/Enums/BarcodeType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BarcodeType
 {
     UPC_A,

--- a/backend/Models/Enums/ContentType.cs
+++ b/backend/Models/Enums/ContentType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ContentType
 {
     Text,

--- a/backend/Models/Enums/PrintStyle.cs
+++ b/backend/Models/Enums/PrintStyle.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PrintStyle
 {
     Normal,

--- a/backend/Models/Enums/QRCodeCorrectionLevel.cs
+++ b/backend/Models/Enums/QRCodeCorrectionLevel.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum QRCodeCorrectionLevel
 {
     Percent7,

--- a/backend/Models/Enums/QRCodeModel.cs
+++ b/backend/Models/Enums/QRCodeModel.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum QRCodeModel
 {
     Model1,

--- a/backend/Models/Enums/QRCodeSize.cs
+++ b/backend/Models/Enums/QRCodeSize.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace ThermalPrinterWeb.Models;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum QRCodeSize
 {
     Normal,

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -19,6 +19,11 @@ builder.Services.AddControllers()
     });
 builder.Services.AddSingleton<IPrinterService, PrinterService>();
 builder.Services.AddPrinterBlockHandlers();
+
+// MCP server over HTTP at /mcp (stateless, no auth - single-user printer).
+builder.Services.AddMcpServer()
+    .WithHttpTransport(o => o.Stateless = true)
+    .WithToolsFromAssembly();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -57,6 +62,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapControllers();
+app.MapMcp("/mcp");
 
 // Serve React app SPA (from wwwroot)
 app.MapFallbackToFile("index.html");

--- a/backend/Services/Printing/SimpleNote.cs
+++ b/backend/Services/Printing/SimpleNote.cs
@@ -1,0 +1,49 @@
+using ThermalPrinterWeb.Models;
+
+namespace ThermalPrinterWeb.Services.Printing;
+
+// Shared by the HTTP simple-print path and the MCP print_note tool so the two
+// render identically.
+internal static class SimpleNote
+{
+    private const int SimpleImageMaxSize = 500;
+
+    public static List<PrintContent> Build(string name, string message, string? imageBase64 = null)
+    {
+        List<PrintContent> content =
+        [
+            new() { Type = ContentType.Separator, SeparatorChar = "=", SeparatorLength = 32 },
+            new()
+            {
+                Type = ContentType.Text,
+                Content = name,
+                Alignment = Alignment.Center,
+                Style = [PrintStyle.DoubleWidth, PrintStyle.DoubleHeight]
+            },
+            new() { Type = ContentType.Separator },
+            new()
+            {
+                Type = ContentType.Text,
+                Content = message,
+                Alignment = Alignment.Center
+            },
+            new() { Type = ContentType.Separator }
+        ];
+
+        if (!string.IsNullOrEmpty(imageBase64))
+        {
+            content.Add(new PrintContent
+            {
+                Type = ContentType.Image,
+                Content = imageBase64,
+                ImageOptions = new ImageOptions { MaxWidth = SimpleImageMaxSize, MaxHeight = SimpleImageMaxSize }
+            });
+            content.Add(new() { Type = ContentType.Separator });
+        }
+
+        content.Add(new() { Type = ContentType.LineFeed, Lines = 3 });
+        content.Add(new() { Type = ContentType.Cut });
+
+        return content;
+    }
+}

--- a/backend/ThermalPrinterWeb.Api.csproj
+++ b/backend/ThermalPrinterWeb.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ESCPOS_NET" Version="3.0.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>


### PR DESCRIPTION
Closes #12.

## What
Exposes the thermal printer over **Model Context Protocol** so MCP clients (Claude Desktop/Code) can drive it directly — alongside the existing HTTP API and the curl-based `thermal-printer` skill.

- `ModelContextProtocol.AspNetCore` **1.4.0** (latest stable), **stateless** HTTP transport, mapped at **`/mcp`**.
- **No auth** — single-user printer; see the decision in #8 (closed won't-do).

## Tools
Discovered via `WithToolsFromAssembly`, each reuses `IPrinterService`:
| tool | purpose |
|------|---------|
| `get_status` | live readiness (reachable / online / cover / paper) — call before printing |
| `print_note` | `title` + `message` (+ optional base64 image) |
| `print` | full content-block document (Text/Image/Barcode/QRCode/LineFeed/Cut/Separator/CodePage) |

## Notable
- **Shared renderer**: extracted the controller's `BuildSimpleContent` into `SimpleNote` so the HTTP simple-print path and `print_note` render identically (no dup).
- **String enums in the tool schema**: added type-level `[JsonConverter(typeof(JsonStringEnumConverter))]` to the print enums. The MVC `AddJsonOptions` converter only configures MVC, not the MCP SDK's serializer — without this, `print`'s schema would advertise enums as ints (e.g. `0` instead of `"Center"`).
- **Public tool type/methods**: `WithToolsFromAssembly` discovers by reflecting over **public** types; `internal` would silently yield an empty `tools/list`.

## Verification (live, local `/mcp`)
- `tools/list` → **3** tools.
- `print`'s `inputSchema` shows enums as string names.
- `tools/call get_status` → `{"ready":true,...}`.
- `tools/call print_note` → `Printed.` (note physically printed via MCP → `IPrinterService` → printer).

## After merge/deploy
Register against the deployed URL:
```
claude mcp add --transport http printer https://printer.vicio.ovh/mcp
```
(no auth header.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)