### PR TITLE
feat: full 576-dot-width images + HighDensity knob (#9)

### DIFF
--- a/backend/Models/Options/ImageOptions.cs
+++ b/backend/Models/Options/ImageOptions.cs
@@ -2,8 +2,12 @@ namespace ThermalPrinterWeb.Models;
 
 public class ImageOptions
 {
-    public int? MaxWidth { get; set; } = 500;
-    public int? MaxHeight { get; set; } = 500;
+    // 576 = full print-head width of the V330M (80mm head); was 500, ~13% short.
+    public int? MaxWidth { get; set; } = 576;
+    public int? MaxHeight { get; set; } = 576;
     public bool PreserveAspectRatio { get; set; } = true;
     public bool UseLegacyMode { get; set; } = true;
+
+    // Maps to ESCPOS PrintImage isHiDPI; true preserves prior behavior.
+    public bool HighDensity { get; set; } = true;
 }

--- a/backend/Services/Printing/Handlers/ImageBlockHandler.cs
+++ b/backend/Services/Printing/Handlers/ImageBlockHandler.cs
@@ -6,8 +6,9 @@ namespace ThermalPrinterWeb.Services.Printing.Handlers;
 
 internal sealed class ImageBlockHandler(ILogger<ImageBlockHandler> logger) : IBlockHandler
 {
-    private const int DefaultMaxWidth = 500;
-    private const int DefaultMaxHeight = 500;
+    // 576 = full V330M print-head width (80mm head).
+    private const int DefaultMaxWidth = 576;
+    private const int DefaultMaxHeight = 576;
 
     public ContentType Type => ContentType.Image;
 
@@ -20,7 +21,8 @@ internal sealed class ImageBlockHandler(ILogger<ImageBlockHandler> logger) : IBl
         if (imageBytes != null)
         {
             var legacy = item.ImageOptions?.UseLegacyMode ?? true;
-            ctx.Add(ctx.Emitter.PrintImage(imageBytes, true, isLegacy: legacy));
+            var highDensity = item.ImageOptions?.HighDensity ?? true;
+            ctx.Add(ctx.Emitter.PrintImage(imageBytes, highDensity, isLegacy: legacy));
         }
     }
 

--- a/backend/Services/Printing/SimpleNote.cs
+++ b/backend/Services/Printing/SimpleNote.cs
@@ -6,8 +6,6 @@ namespace ThermalPrinterWeb.Services.Printing;
 // render identically.
 internal static class SimpleNote
 {
-    private const int SimpleImageMaxSize = 500;
-
     public static List<PrintContent> Build(string name, string message, string? imageBase64 = null)
     {
         List<PrintContent> content =
@@ -35,8 +33,7 @@ internal static class SimpleNote
             content.Add(new PrintContent
             {
                 Type = ContentType.Image,
-                Content = imageBase64,
-                ImageOptions = new ImageOptions { MaxWidth = SimpleImageMaxSize, MaxHeight = SimpleImageMaxSize }
+                Content = imageBase64
             });
             content.Add(new() { Type = ContentType.Separator });
         }


### PR DESCRIPTION
Closes #9.

## What
Images were capped at **500** dots wide, but the V330M head is **576** — so prints were ~13% short of full width. This bumps the default to 576 and surfaces the previously-hardcoded hi-DPI flag.

- `ImageOptions.MaxWidth`/`MaxHeight` **500 → 576**; same for `ImageBlockHandler`'s fallback constants.
- New `ImageOptions.HighDensity` (default **true**) → passed as `PrintImage`'s `isHiDPI`. Default preserves current behavior.
- `UseLegacyMode` was already exposed; aspect ratio still preserved (`ResizeMode.Max`).
- `SimpleNote` drops its explicit 500 cap → simple-mode images inherit the 576 default.

## No dither knob (deliberate)
ESCPOS_NET applies **Stucki** dithering internally, and `PrintImage` exposes no cheap dither parameter — verified by reflecting the installed 3.0.0 DLL:
```
PrintImage(byte[] image, bool isHiDPI, bool isLegacy=false, int maxWidth=-1, int color=1)
```
The issue scoped dither as "if cheap"; it isn't, so skipped (no double-dithering risk).

## Verification (live)
A/B of a 576px width-marker image (ticks every 64px, edge bars): deployed master prints it guttered at ~500 dots; this branch fills the head to both margins at 576.

## Acceptance
- [x] Wide source prints full 576-dot width.
- [x] `ImageOptions` toggles legacy/hi-dpi; defaults preserve behavior (`isLegacy=true`, hi-DPI on).
- [x] Aspect ratio preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)