### PR TITLE
ci: adopt shared dotnet-docker-deploy workflow (clears Node 20 deprecation)

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -12,50 +12,14 @@ permissions:
   packages: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
-
-  deploy:
-    needs: build
-    if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, homelab]
-
-    steps:
-      - name: Deploy to homelab
-        run: |
-          cd /home/ubuntu/docker/thermal-printer-web
-          docker compose pull
-          docker compose up -d
+  build-deploy:
+    uses: wiktorkowalski/github-workflows/.github/workflows/dotnet-docker-deploy.yml@master
+    with:
+      image-name: wiktorkowalski/thermal-printer-web
+      dockerfile: ./Dockerfile
+      context: .
+      # Empty: the multi-stage Dockerfile builds the frontend + .NET itself.
+      dotnet-project: ""
+      deploy-compose-path: /home/ubuntu/docker/thermal-printer-web
+      deploy-runner-labels: '["self-hosted", "homelab"]'
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,9 +238,9 @@ The `POST /api/printer` endpoint accepts print jobs in two modes:
 
 ## CI/CD
 
-GitHub Actions workflow (`.github/workflows/docker-image-ci.yml`) builds and pushes Docker images to GitHub Container Registry on:
-- Push to master branch
-- Pull requests to master
+GitHub Actions workflow (`.github/workflows/docker-image-ci.yml`) calls the shared reusable workflow `wiktorkowalski/github-workflows/.github/workflows/dotnet-docker-deploy.yml@master`, which builds + pushes the Docker image to GitHub Container Registry, then deploys via `docker compose` on the self-hosted homelab runner. Triggers:
+- Push to master branch (build + push + deploy)
+- Pull requests to master (build only, no push/deploy)
 - Manual workflow dispatch
 
-Images are tagged with: `sha-<commit>`, branch name, and `latest`.
+Images are tagged with: `<commit>` (full SHA) and `latest`. Build cache uses GitHub Actions cache (`type=gha`). The homelab compose references `:latest`.


### PR DESCRIPTION
## What
Replaces this repo's inline build/deploy jobs with a call to the shared reusable workflow `wiktorkowalski/github-workflows/.github/workflows/dotnet-docker-deploy.yml@master`.

Net: `docker-image-ci.yml` goes 62 → 24 lines, and every action moves off **deprecated Node 20** (the annotation on every run):

| action | before | after |
|--------|--------|-------|
| checkout | v4 | **v6** |
| setup-buildx | v3 | **v4** |
| login | v3 | **v4** |
| metadata | v5 | **v6** |
| build-push | v5 | **v7** |

## Behavior deltas (intentional)
- **Image tags**: `sha-<commit>` + branch + `latest` → `<commit>` (full SHA, no `sha-` prefix) + `latest`. The homelab compose pulls `:latest` (confirmed from the running container image), so **deploys are unaffected**; only manual `sha-`/branch tag references change.
- **Cache**: registry `buildcache` → GitHub Actions cache (`type=gha`).
- **Platform**: build pinned to `linux/amd64`.
- **`dotnet-project` empty** → the multi-stage Dockerfile keeps building frontend + .NET (no separate `dotnet build`/`test` step, matching today).
- Check name changes from `build` to `build-deploy / Build` (no branch-protection rules reference it).

## Unchanged
- PR = build only (no push, no deploy). Master push + `workflow_dispatch` = build + push + deploy on `[self-hosted, homelab]`.
- `CLAUDE.md` CI/CD section updated to match the new tag scheme + shared-workflow setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)