### PR TITLE
deps: bump ImageSharp 2.1.10 -> 2.1.13 (clears NU1902)

### DIFF
--- a/backend/ThermalPrinterWeb.Api.csproj
+++ b/backend/ThermalPrinterWeb.Api.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ESCPOS_NET" Version="3.0.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## What
Bumps `SixLabors.ImageSharp` **2.1.10 → 2.1.13** to clear the medium-severity advisory **GHSA-rxmq-m78w-7wmc** (`NU1902` — infinite loop in the GIF decoder on malformed comment-extension blocks), which is patched in 2.1.11. 2.1.13 is the latest 2.x patch — stays Apache-2.0, no API changes.

## Why not 3.x
We tried `3.1.12` first. It **builds** (NuGet's `>=2.1.3` minimum from ESCPOS_NET lets 3.x satisfy resolution) but **breaks image printing at runtime**:

```
MissingMethodException: SixLabors.ImageSharp.Image.Load(Byte[])
  at ESCPOS_NET.Emitters.BaseCommandEmitter.PrintImage(...)
```

`ESCPOS_NET` 3.0.0 (the latest, used for `PrintImage`) is compiled against ImageSharp 2.x and calls the **`Image.Load(byte[])`** overload that **3.x removed**. With no newer ESCPOS_NET published, 2.x is the compatible ceiling for this app's image path. (Captured this in the commit message so 3.x doesn't get re-attempted.)

## Verification
- Clean rebuild: 0 errors, **0 warnings** (NU1902 gone).
- Live: image print returns `success: true` on 2.1.13 (the same payload threw `MissingMethodException` on 3.1.12).

Pure dependency bump — no `.cs` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)