### PR TITLE
feat: software buzzer control via ESC B (beep without printing)

### DIFF
--- a/backend/Controllers/PrinterController.cs
+++ b/backend/Controllers/PrinterController.cs
@@ -51,4 +51,15 @@ public class PrinterController(ILogger<PrinterController> logger, IPrinterServic
             status.Ready, status.NotReadyReason ?? "ok");
         return status.Reachable ? Ok(status) : StatusCode(503, status);
     }
+
+    [HttpPost("beep")]
+    [ProducesResponseType(typeof(PrintResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PrintResponse), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> Beep([FromQuery] int count = 1, [FromQuery] int duration = 1)
+    {
+        var ok = await printerService.BeepAsync(count, duration);
+        return ok
+            ? Ok(new PrintResponse(true))
+            : StatusCode(503, new PrintResponse(false, "Printer unreachable", "printer"));
+    }
 }

--- a/backend/Mcp/PrinterTools.cs
+++ b/backend/Mcp/PrinterTools.cs
@@ -30,6 +30,17 @@ public static class PrinterTools
         return result.Success ? "Printed." : $"Not printed: {result.Error}";
     }
 
+    [McpServerTool(Name = "beep")]
+    [Description("Sound the printer's buzzer without printing - an audible way to get Wiktor's attention. count = number of beeps (1-9), duration = length of each (1-9).")]
+    public static async Task<string> BeepAsync(
+        IPrinterService printer,
+        [Description("Number of beeps, 1-9.")] int count = 1,
+        [Description("Duration of each beep, 1-9.")] int duration = 1)
+    {
+        var ok = await printer.BeepAsync(count, duration);
+        return ok ? $"Beeped {count}x." : "Beep failed: printer unreachable.";
+    }
+
     [McpServerTool(Name = "print")]
     [Description("Print a custom document: an ordered list of content blocks (Text, Image, Barcode, QRCode, LineFeed, Cut, Separator, CodePage). Use for full control over styling, barcodes, QR codes and images.")]
     public static async Task<string> PrintAsync(

--- a/backend/Services/IPrinterService.cs
+++ b/backend/Services/IPrinterService.cs
@@ -7,4 +7,6 @@ public interface IPrinterService
     Task<PrintResult> PrintAsync(List<PrintContent> content, PrintOptions? options = null);
 
     Task<PrinterStatus> GetStatusAsync();
+
+    Task<bool> BeepAsync(int count, int duration);
 }

--- a/backend/Services/PrinterService.cs
+++ b/backend/Services/PrinterService.cs
@@ -20,6 +20,10 @@ internal sealed class PrinterService(ILogger<PrinterService> logger, IEnumerable
     // for anything outside ASCII, so default to Latin-2 (covers Polish) instead.
     private const string DefaultCodePage = "PC852";
 
+    // ESC B n t (1B 42): buzzer - n beeps each of length t. Both clamp to 1..9.
+    private const int BuzzerMin = 1;
+    private const int BuzzerMax = 9;
+
     public async Task<PrintResult> PrintAsync(List<PrintContent> content, PrintOptions? options = null)
     {
         try
@@ -152,6 +156,29 @@ internal sealed class PrinterService(ILogger<PrinterService> logger, IEnumerable
         {
             logger.LogWarning(ex, "Failed to read printer status from {Address}", PrinterAddress);
             return new PrinterStatus(false, false, false, false, false, ex.Message);
+        }
+    }
+
+    public async Task<bool> BeepAsync(int count, int duration)
+    {
+        var n = Math.Clamp(count, BuzzerMin, BuzzerMax);
+        var t = Math.Clamp(duration, BuzzerMin, BuzzerMax);
+        var (host, port) = ParseAddress(PrinterAddress);
+        try
+        {
+            using var client = new TcpClient();
+            using var connectCts = new CancellationTokenSource(ConnectTimeout);
+            await client.ConnectAsync(host, port, connectCts.Token);
+            using var stream = client.GetStream();
+            byte[] command = [0x1B, 0x42, (byte)n, (byte)t]; // ESC B n t
+            await stream.WriteAsync(command);
+            logger.LogInformation("Buzzer beeped {Count} time(s), duration {Duration}", n, t);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Buzzer beep failed ({Address})", PrinterAddress);
+            return false;
         }
     }
 


### PR DESCRIPTION
## What
The V330M buzzer (previously only known to fire as a hardware alarm on cover-open/paper-out) is **software-triggerable** via ESC/POS `ESC B n t` (`1B 42 n t`): n beeps of length t. Now exposed three ways:

- **`IPrinterService.BeepAsync(count, duration)`** — sends the 4 raw bytes over a fresh TCP socket (same raw path as the `DLE EOT` status probe; ESCPOS_NET has no buzzer method). Clamps n/t to the valid **1–9**.
- **`POST /api/printer/beep?count=&duration=`** — beep with no print.
- **MCP `beep` tool** — an audible "look at this" signal (`tools/list` now returns 4).

## Verification (live, on hardware)
`ESC B n t` confirmed working, and **n maps to beep count exactly** — verified by ear at n=2, n=3, and n=5. Both the HTTP endpoint and the MCP tool sound the buzzer.

## Notes
- Buzzer fires independently of a print job (own socket, no readiness gate).
- Possible follow-up (not in this PR): a `Beep` content block so a print job can beep mid-document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)